### PR TITLE
metrics and graphs (via node-exporter and cAdvisor)

### DIFF
--- a/envs/sbx/infra/16-kube-state-metrics.yml
+++ b/envs/sbx/infra/16-kube-state-metrics.yml
@@ -1,0 +1,1 @@
+../../../lib/infra/16-kube-state-metrics.yml

--- a/envs/sbx/infra/17-cadvisor.yml
+++ b/envs/sbx/infra/17-cadvisor.yml
@@ -1,0 +1,1 @@
+../../../lib/infra/17-cadvisor.yml

--- a/envs/sbx/infra/18-node-exporter.yml
+++ b/envs/sbx/infra/18-node-exporter.yml
@@ -1,0 +1,1 @@
+../../../lib/infra/18-node-exporter.yml

--- a/lib/infra/14-prometheus.yml
+++ b/lib/infra/14-prometheus.yml
@@ -80,6 +80,9 @@ data:
                 # - http://alertmanaged.infra.svc.cluster.local:
           scheme: http
           timeout: 10s
+    rule_files:
+      - /opt/prometheus-kubernetes-monitoring/prometheus_alerts.yml
+      - /opt/prometheus-kubernetes-monitoring/prometheus_rules.yml
     scrape_configs:
       - job_name: prometheus
         scrape_interval: 15s
@@ -104,6 +107,7 @@ data:
             target_label: kubernetes_pod_name
           - action: labeldrop
             regex: '(pod_template_hash)'
+
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -125,23 +129,21 @@ spec:
       serviceAccountName: prometheus
       terminationGracePeriodSeconds: 30
       containers:
-      # - image: quay.io/coreos/prometheus-operator:v0.17.0
       - image: prom/prometheus:v2.4.0
         imagePullPolicy: Always
         name: prometheus
         args:
-          # TODO(adam): Just deploy prom operator and copy config
-          # - --kubelet-service=kube-system/kubelet
-          # - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-          #
           - --config.file=/opt/prometheus/prometheus.yml
           - --storage.tsdb.path=/prometheus
+          - --storage.tsdb.retention=30d
           - --web.console.libraries=/usr/share/prometheus/console_libraries
           - --web.console.templates=/usr/share/prometheus/consoles
           - --web.external-url=https://infra.moov.io/prometheus/
         volumeMounts:
           - name: prometheus-config
             mountPath: /opt/prometheus/
+          - name: prometheus-kubernets-monitoring
+            mountPath: /opt/prometheus-kubernetes-monitoring/
           - name: prometheus-data
             mountPath: /data/prometheus
         ports:
@@ -155,6 +157,14 @@ spec:
             items:
               - key: prometheus.yml
                 path: prometheus.yml
+        - name: prometheus-kubernets-monitoring
+          configMap:
+            name: prometheus-kubernets-monitoring
+            items:
+              - key: prometheus_alerts.yml
+                path: prometheus_alerts.yml
+              - key: prometheus_rules.yml
+                path: prometheus_rules.yml
         - name: prometheus-data
           persistentVolumeClaim:
             claimName: prometheus-data
@@ -230,3 +240,619 @@ subjects:
     namespace: infra
 
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-kubernets-monitoring
+  namespace: infra
+data:
+  # THIS FILE WAS GENERATED FROM https://github.com/kubernetes-monitoring/kubernetes-mixin
+  prometheus_alerts.yml: |
+    "groups":
+      - "name": "kubernetes-absent"
+        "rules":
+          - "alert": "KubeAPIDown"
+            "annotations":
+              "message": "KubeAPI has disappeared from Prometheus target discovery."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapidown"
+            "expr": |
+              absent(up{job="kube-apiserver"} == 1)
+            "for": "15m"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubeControllerManagerDown"
+            "annotations":
+              "message": "KubeControllerManager has disappeared from Prometheus target discovery."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontrollermanagerdown"
+            "expr": |
+              absent(up{job="kube-controller-manager"} == 1)
+            "for": "15m"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubeSchedulerDown"
+            "annotations":
+              "message": "KubeScheduler has disappeared from Prometheus target discovery."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeschedulerdown"
+            "expr": |
+              absent(up{job="kube-scheduler"} == 1)
+            "for": "15m"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubeletDown"
+            "annotations":
+              "message": "Kubelet has disappeared from Prometheus target discovery."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown"
+            "expr": |
+              absent(up{job="kubelet"} == 1)
+            "for": "15m"
+            "labels":
+              "severity": "critical"
+      - "name": "kubernetes-apps"
+        "rules":
+          - "alert": "KubePodCrashLooping"
+            "annotations":
+              "message": "Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf \"%.2f\" $value }} times / second."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping"
+            "expr": |
+              rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) > 0
+            "for": "1h"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubePodNotReady"
+            "annotations":
+              "message": "Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than an hour."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready"
+            "expr": |
+              sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) > 0
+            "for": "1h"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubeDeploymentGenerationMismatch"
+            "annotations":
+              "message": "Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has not been rolled back."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch"
+            "expr": |
+              kube_deployment_status_observed_generation{job="kube-state-metrics"}
+              !=
+              kube_deployment_metadata_generation{job="kube-state-metrics"}
+            "for": "15m"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubeDeploymentReplicasMismatch"
+            "annotations":
+              "message": "Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than an hour."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch"
+            "expr": |
+              kube_deployment_spec_replicas{job="kube-state-metrics"}
+              !=
+              kube_deployment_status_replicas_available{job="kube-state-metrics"}
+            "for": "1h"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubeStatefulSetReplicasMismatch"
+            "annotations":
+              "message": "StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected number of replicas for longer than 15 minutes."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch"
+            "expr": |
+              kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
+              !=
+              kube_statefulset_status_replicas{job="kube-state-metrics"}
+            "for": "15m"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubeStatefulSetGenerationMismatch"
+            "annotations":
+              "message": "StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has not been rolled back."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch"
+            "expr": |
+              kube_statefulset_status_observed_generation{job="kube-state-metrics"}
+              !=
+              kube_statefulset_metadata_generation{job="kube-state-metrics"}
+            "for": "15m"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubeDaemonSetRolloutStuck"
+            "annotations":
+              "message": "Only {{ $value }}% of the desired Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are scheduled and ready."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck"
+            "expr": |
+              kube_daemonset_status_number_ready{job="kube-state-metrics"}
+              /
+              kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"} * 100 < 100
+            "for": "15m"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubeDaemonSetNotScheduled"
+            "annotations":
+              "message": "{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are not scheduled."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled"
+            "expr": |
+              kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+              -
+                kube_daemonset_status_current_number_scheduled{job="kube-state-metrics"} > 0
+            "for": "10m"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeDaemonSetMisScheduled"
+            "annotations":
+              "message": "{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are running where they are not supposed to run."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled"
+            "expr": |
+              kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} > 0
+            "for": "10m"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeCronJobRunning"
+            "annotations":
+              "message": "CronJob {{ $labels.namespaces }}/{{ $labels.cronjob }} is taking more than 1h to complete."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning"
+            "expr": |
+              time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"} > 3600
+            "for": "1h"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeJobCompletion"
+            "annotations":
+              "message": "Job {{ $labels.namespaces }}/{{ $labels.job }} is taking more than one hour to complete."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion"
+            "expr": |
+              kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}  > 0
+            "for": "1h"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeJobFailed"
+            "annotations":
+              "message": "Job {{ $labels.namespaces }}/{{ $labels.job }} failed to complete."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed"
+            "expr": |
+              kube_job_status_failed{job="kube-state-metrics"}  > 0
+            "for": "1h"
+            "labels":
+              "severity": "warning"
+      - "name": "kubernetes-resources"
+        "rules":
+          - "alert": "KubeCPUOvercommit"
+            "annotations":
+              "message": "Cluster has overcommitted CPU resource requests for Pods and cannot tolerate node failure."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit"
+            "expr": |
+              sum(namespace_name:kube_pod_container_resource_requests_cpu_cores:sum)
+              /
+              sum(node:node_num_cpu:sum)
+              >
+              (count(node:node_num_cpu:sum)-1) / count(node:node_num_cpu:sum)
+            "for": "5m"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeMemOvercommit"
+            "annotations":
+              "message": "Cluster has overcommitted memory resource requests for Pods and cannot tolerate node failure."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememovercommit"
+            "expr": |
+              sum(namespace_name:kube_pod_container_resource_requests_memory_bytes:sum)
+              /
+              sum(node_memory_MemTotal)
+              >
+              (count(node:node_num_cpu:sum)-1)
+              /
+              count(node:node_num_cpu:sum)
+            "for": "5m"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeCPUOvercommit"
+            "annotations":
+              "message": "Cluster has overcommitted CPU resource requests for Namespaces."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit"
+            "expr": |
+              sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="requests.cpu"})
+              /
+              sum(node:node_num_cpu:sum)
+              > 1.5
+            "for": "5m"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeMemOvercommit"
+            "annotations":
+              "message": "Cluster has overcommitted memory resource requests for Namespaces."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememovercommit"
+            "expr": |
+              sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="requests.memory"})
+              /
+              sum(node_memory_MemTotal{job="node-exporter"})
+              > 1.5
+            "for": "5m"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeQuotaExceeded"
+            "annotations":
+              "message": "Namespace {{ $labels.namespace }} is using {{ printf \"%0.0f\" $value }}% of its {{ $labels.resource }} quota."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotaexceeded"
+            "expr": |
+              100 * kube_resourcequota{job="kube-state-metrics", type="used"}
+              / ignoring(instance, job, type)
+              kube_resourcequota{job="kube-state-metrics", type="hard"}
+              > 90
+            "for": "15m"
+            "labels":
+              "severity": "warning"
+      - "name": "kubernetes-storage"
+        "rules":
+          - "alert": "KubePersistentVolumeUsageCritical"
+            "annotations":
+              "message": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ printf \"%0.0f\" $value }}% free."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeusagecritical"
+            "expr": |
+              100 * kubelet_volume_stats_available_bytes{job="kubelet"}
+              /
+              kubelet_volume_stats_capacity_bytes{job="kubelet"}
+              < 3
+            "for": "1m"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubePersistentVolumeFullInFourDays"
+            "annotations":
+              "message": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value }} bytes are available."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefullinfourdays"
+            "expr": |
+              kubelet_volume_stats_available_bytes{job="kubelet"} and predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600) < 0
+            "for": "5m"
+            "labels":
+              "severity": "critical"
+      - "name": "kubernetes-system"
+        "rules":
+          - "alert": "KubeNodeNotReady"
+            "annotations":
+              "message": "{{ $labels.node }} has been unready for more than an hour."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodenotready"
+            "expr": |
+              kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
+            "for": "1h"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeVersionMismatch"
+            "annotations":
+              "message": "There are {{ $value }} different versions of Kubernetes components running."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch"
+            "expr": |
+              count(count(kubernetes_build_info{job!="kube-dns"}) by (gitVersion)) > 1
+            "for": "1h"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeClientErrors"
+            "annotations":
+              "message": "Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }}% errors.'"
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors"
+            "expr": |
+              (sum(rate(rest_client_requests_total{code!~"2..|404"}[5m])) by (instance, job)
+              /
+              sum(rate(rest_client_requests_total[5m])) by (instance, job))
+              * 100 > 1
+            "for": "15m"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeClientErrors"
+            "annotations":
+              "message": "Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ printf \"%0.0f\" $value }} errors / second."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors"
+            "expr": |
+              sum(rate(ksm_scrape_error_total{job="kube-state-metrics"}[5m])) by (instance, job) > 0.1
+            "for": "15m"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeletTooManyPods"
+            "annotations":
+              "message": "Kubelet {{ $labels.instance }} is running {{ $value }} Pods, close to the limit of 110."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods"
+            "expr": |
+              kubelet_running_pod_count{job="kubelet"} > 110 * 0.9
+            "for": "15m"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeAPILatencyHigh"
+            "annotations":
+              "message": "The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh"
+            "expr": |
+              cluster_quantile:apiserver_request_latencies:histogram_quantile{job="kube-apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 1
+            "for": "10m"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeAPILatencyHigh"
+            "annotations":
+              "message": "The API server has a 99th percentile latency of {{ $value }} seconds for {{ $labels.verb }} {{ $labels.resource }}."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh"
+            "expr": |
+              cluster_quantile:apiserver_request_latencies:histogram_quantile{job="kube-apiserver",quantile="0.99",subresource!="log",verb!~"^(?:LIST|WATCH|WATCHLIST|PROXY|CONNECT)$"} > 4
+            "for": "10m"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubeAPIErrorsHigh"
+            "annotations":
+              "message": "API server is returning errors for {{ $value }}% of requests."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh"
+            "expr": |
+              sum(rate(apiserver_request_count{job="kube-apiserver",code=~"^(?:5..)$"}[5m])) without(instance, pod)
+              /
+              sum(rate(apiserver_request_count{job="kube-apiserver"}[5m])) without(instance, pod) * 100 > 10
+            "for": "10m"
+            "labels":
+              "severity": "critical"
+          - "alert": "KubeAPIErrorsHigh"
+            "annotations":
+              "message": "API server is returning errors for {{ $value }}% of requests."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorshigh"
+            "expr": |
+              sum(rate(apiserver_request_count{job="kube-apiserver",code=~"^(?:5..)$"}[5m])) without(instance, pod)
+              /
+              sum(rate(apiserver_request_count{job="kube-apiserver"}[5m])) without(instance, pod) * 100 > 5
+            "for": "10m"
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeClientCertificateExpiration"
+            "annotations":
+              "message": "Kubernetes API certificate is expiring in less than 7 days."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration"
+            "expr": |
+              histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="kube-apiserver"}[5m]))) < 604800
+            "labels":
+              "severity": "warning"
+          - "alert": "KubeClientCertificateExpiration"
+            "annotations":
+              "message": "Kubernetes API certificate is expiring in less than 24 hours."
+              "runbook_url": "https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration"
+            "expr": |
+              histogram_quantile(0.01, sum by (job, le) (rate(apiserver_client_certificate_expiration_seconds_bucket{job="kube-apiserver"}[5m]))) < 86400
+            "labels":
+              "severity": "critical"
+  # THIS FILE WAS GENERATED FROM https://github.com/kubernetes-monitoring/kubernetes-mixin
+  prometheus_rules.yml: |
+    "groups":
+      - "name": "k8s.rules"
+        "rules":
+          - "expr": |
+              sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])) by (namespace)
+            "record": "namespace:container_cpu_usage_seconds_total:sum_rate"
+          - "expr": |
+              sum by (namespace, pod_name, container_name) (
+              rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m]))
+            "record": "namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate"
+          - "expr": |
+              sum(container_memory_usage_bytes{job="cadvisor", image!="", container_name!=""}) by (namespace)
+            "record": "namespace:container_memory_usage_bytes:sum"
+          - "expr": |
+              sum by (namespace, label_name) (
+              sum(rate(container_cpu_usage_seconds_total{job="cadvisor", image!="", container_name!=""}[5m])) by (namespace, pod_name)
+              * on (namespace, pod_name) group_left(label_name)
+              label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)"))
+            "record": "namespace_name:container_cpu_usage_seconds_total:sum_rate"
+          - "expr": |
+              sum by (namespace, label_name) (
+              sum(container_memory_usage_bytes{job="cadvisor",image!="", container_name!=""}) by (pod_name, namespace)
+              * on (namespace, pod_name) group_left(label_name)
+              label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)"))
+            "record": "namespace_name:container_memory_usage_bytes:sum"
+          - "expr": |
+              sum by (namespace, label_name) (
+              sum(kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"}) by (namespace, pod)
+              * on (namespace, pod) group_left(label_name)
+              label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)"))
+            "record": "namespace_name:kube_pod_container_resource_requests_memory_bytes:sum"
+          - "expr": |
+              sum by (namespace, label_name) (
+              sum(kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"} and on(pod) kube_pod_status_scheduled{condition="true"}) by (namespace, pod)
+              * on (namespace, pod) group_left(label_name)
+              label_replace(kube_pod_labels{job="kube-state-metrics"}, "pod_name", "$1", "pod", "(.*)"))
+            "record": "namespace_name:kube_pod_container_resource_requests_cpu_cores:sum"
+      - "name": "kube-scheduler.rules"
+        "rules":
+          - "expr": |
+              histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+            "labels":
+              "quantile": "0.99"
+            "record": "cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile"
+          - "expr": |
+              histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+            "labels":
+              "quantile": "0.99"
+            "record": "cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile"
+          - "expr": |
+              histogram_quantile(0.99, sum(rate(scheduler_binding_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+            "labels":
+              "quantile": "0.99"
+            "record": "cluster_quantile:scheduler_binding_latency:histogram_quantile"
+          - "expr": |
+              histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+            "labels":
+              "quantile": "0.9"
+            "record": "cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile"
+          - "expr": |
+              histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+            "labels":
+              "quantile": "0.9"
+            "record": "cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile"
+          - "expr": |
+              histogram_quantile(0.9, sum(rate(scheduler_binding_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+            "labels":
+              "quantile": "0.9"
+            "record": "cluster_quantile:scheduler_binding_latency:histogram_quantile"
+          - "expr": |
+              histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+            "labels":
+              "quantile": "0.5"
+            "record": "cluster_quantile:scheduler_e2e_scheduling_latency:histogram_quantile"
+          - "expr": |
+              histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+            "labels":
+              "quantile": "0.5"
+            "record": "cluster_quantile:scheduler_scheduling_algorithm_latency:histogram_quantile"
+          - "expr": |
+              histogram_quantile(0.5, sum(rate(scheduler_binding_latency_microseconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod)) / 1e+06
+            "labels":
+              "quantile": "0.5"
+            "record": "cluster_quantile:scheduler_binding_latency:histogram_quantile"
+      - "name": "kube-apiserver.rules"
+        "rules":
+          - "expr": |
+              histogram_quantile(0.99, sum(rate(apiserver_request_latencies_bucket{job="kube-apiserver"}[5m])) without(instance, pod)) / 1e+06
+            "labels":
+              "quantile": "0.99"
+            "record": "cluster_quantile:apiserver_request_latencies:histogram_quantile"
+          - "expr": |
+              histogram_quantile(0.9, sum(rate(apiserver_request_latencies_bucket{job="kube-apiserver"}[5m])) without(instance, pod)) / 1e+06
+            "labels":
+              "quantile": "0.9"
+            "record": "cluster_quantile:apiserver_request_latencies:histogram_quantile"
+          - "expr": |
+              histogram_quantile(0.5, sum(rate(apiserver_request_latencies_bucket{job="kube-apiserver"}[5m])) without(instance, pod)) / 1e+06
+            "labels":
+              "quantile": "0.5"
+            "record": "cluster_quantile:apiserver_request_latencies:histogram_quantile"
+      - "name": "node.rules"
+        "rules":
+          - "expr": "sum(min(kube_pod_info) by (node))"
+            "record": ":kube_pod_info_node_count:"
+          - "expr": |
+              max(label_replace(kube_pod_info{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")) by (node, namespace, pod)
+            "record": "node_namespace_pod:kube_pod_info:"
+          - "expr": |
+              count by (node) (sum by (node, cpu) (
+              node_cpu{job="node-exporter"}
+              * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+              ))
+            "record": "node:node_num_cpu:sum"
+          - "expr": |
+              1 - avg(rate(node_cpu{job="node-exporter",mode="idle"}[1m]))
+            "record": ":node_cpu_utilisation:avg1m"
+          - "expr": |
+              1 - avg by (node) (
+              rate(node_cpu{job="node-exporter",mode="idle"}[1m])
+              * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:)
+            "record": "node:node_cpu_utilisation:avg1m"
+          - "expr": |
+              sum(node_load1{job="node-exporter"})
+              /
+              sum(node:node_num_cpu:sum)
+            "record": ":node_cpu_saturation_load1:"
+          - "expr": |
+              sum by (node) (
+              node_load1{job="node-exporter"}
+              * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:)
+              /
+              node:node_num_cpu:sum
+            "record": "node:node_cpu_saturation_load1:"
+          - "expr": |
+              1 -
+              sum(node_memory_MemFree{job="node-exporter"} + node_memory_Cached{job="node-exporter"} + node_memory_Buffers{job="node-exporter"})
+              /
+              sum(node_memory_MemTotal{job="node-exporter"})
+            "record": ":node_memory_utilisation:"
+          - "expr": |
+              sum(node_memory_MemFree{job="node-exporter"} + node_memory_Cached{job="node-exporter"} + node_memory_Buffers{job="node-exporter"})
+            "record": ":node_memory_MemFreeCachedBuffers:sum"
+          - "expr": |
+              sum(node_memory_MemTotal{job="node-exporter"})
+            "record": ":node_memory_MemTotal:sum"
+          - "expr": |
+              sum by (node) (
+              (node_memory_MemFree{job="node-exporter"} + node_memory_Cached{job="node-exporter"} + node_memory_Buffers{job="node-exporter"})
+              * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:)
+            "record": "node:node_memory_bytes_available:sum"
+          - "expr": |
+              sum by (node) (
+              node_memory_MemTotal{job="node-exporter"}
+              * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+              )
+            "record": "node:node_memory_bytes_total:sum"
+          - "expr": |
+              (node:node_memory_bytes_total:sum - node:node_memory_bytes_available:sum)
+              /
+              scalar(sum(node:node_memory_bytes_total:sum))
+            "record": "node:node_memory_utilisation:ratio"
+          - "expr": |
+              1e3 * sum(
+              (rate(node_vmstat_pgpgin{job="node-exporter"}[1m])
+              + rate(node_vmstat_pgpgout{job="node-exporter"}[1m]))
+              )
+            "record": ":node_memory_swap_io_bytes:sum_rate"
+          - "expr": |
+              1 -
+              sum by (node) (
+              (node_memory_MemFree{job="node-exporter"} + node_memory_Cached{job="node-exporter"} + node_memory_Buffers{job="node-exporter"})
+              * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+              )
+              /
+              sum by (node) (
+              node_memory_MemTotal{job="node-exporter"}
+              * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+              )
+            "record": "node:node_memory_utilisation:"
+          - "expr": |
+              1 - (node:node_memory_bytes_available:sum / node:node_memory_bytes_total:sum)
+            "record": "node:node_memory_utilisation_2:"
+          - "expr": |
+              1e3 * sum by (node) (
+              (rate(node_vmstat_pgpgin{job="node-exporter"}[1m])
+              + rate(node_vmstat_pgpgout{job="node-exporter"}[1m]))
+              * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+              )
+            "record": "node:node_memory_swap_io_bytes:sum_rate"
+          - "expr": |
+              avg(irate(node_disk_io_time_ms{job="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]) / 1e3)
+            "record": ":node_disk_utilisation:avg_irate"
+          - "expr": |
+              avg by (node) (
+              irate(node_disk_io_time_ms{job="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]) / 1e3
+              * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+              )
+            "record": "node:node_disk_utilisation:avg_irate"
+          - "expr": |
+              avg(irate(node_disk_io_time_weighted{job="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]) / 1e3)
+            "record": ":node_disk_saturation:avg_irate"
+          - "expr": |
+              avg by (node) (
+              irate(node_disk_io_time_weighted{job="node-exporter",device=~"(sd|xvd|nvme).+"}[1m]) / 1e3
+              * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+              )
+            "record": "node:node_disk_saturation:avg_irate"
+          - "expr": |
+              max by (namespace, pod, device) ((node_filesystem_size{fstype=~"ext[234]|btrfs|xfs|zfs"}
+              - node_filesystem_avail{fstype=~"ext[234]|btrfs|xfs|zfs"})
+              / node_filesystem_size{fstype=~"ext[234]|btrfs|xfs|zfs"})
+            "record": "node:node_filesystem_usage:"
+          - "expr": |
+              max by (namespace, pod, device) (node_filesystem_avail{fstype=~"ext[234]|btrfs|xfs|zfs"} / node_filesystem_size{fstype=~"ext[234]|btrfs|xfs|zfs"})
+            "record": "node:node_filesystem_avail:"
+          - "expr": |
+              sum(irate(node_network_receive_bytes{job="node-exporter",device="eth0"}[1m])) +
+              sum(irate(node_network_transmit_bytes{job="node-exporter",device="eth0"}[1m]))
+            "record": ":node_net_utilisation:sum_irate"
+          - "expr": |
+              sum by (node) (
+              (irate(node_network_receive_bytes{job="node-exporter",device="eth0"}[1m]) +
+              irate(node_network_transmit_bytes{job="node-exporter",device="eth0"}[1m]))
+              * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+              )
+            "record": "node:node_net_utilisation:sum_irate"
+          - "expr": |
+              sum(irate(node_network_receive_drop{job="node-exporter",device="eth0"}[1m])) +
+              sum(irate(node_network_transmit_drop{job="node-exporter",device="eth0"}[1m]))
+            "record": ":node_net_saturation:sum_irate"
+          - "expr": |
+              sum by (node) (
+              (irate(node_network_receive_drop{job="node-exporter",device="eth0"}[1m]) +
+              irate(node_network_transmit_drop{job="node-exporter",device="eth0"}[1m]))
+              * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+              )
+            "record": "node:node_net_saturation:sum_irate"

--- a/lib/infra/16-kube-state-metrics.yml
+++ b/lib/infra/16-kube-state-metrics.yml
@@ -1,0 +1,147 @@
+# Docs
+# https://github.com/kubernetes/kube-state-metrics#kubernetes-deployment
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: infra
+  labels:
+    k8s-app: kube-state-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+    protocol: TCP
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+    protocol: TCP
+  selector:
+    k8s-app: kube-state-metrics
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: infra
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+  namespace: infra
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-state-metrics
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-state-metrics
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+      - name: kube-state-metrics
+        image: quay.io/coreos/kube-state-metrics:v1.4.0
+        ports:
+        - name: http-metrics
+          containerPort: 8080
+        - name: telemetry
+          containerPort: 8081
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+      - name: addon-resizer
+        image: k8s.gcr.io/addon-resizer:1.7
+        resources:
+          limits:
+            cpu: 100m
+            memory: 30Mi
+          requests:
+            cpu: 100m
+            memory: 30Mi
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        command:
+          - /pod_nanny
+          - --container=kube-state-metrics
+          - --cpu=100m
+          - --extra-cpu=1m
+          - --memory=100Mi
+          - --extra-memory=2Mi
+          - --threshold=5
+          - --deployment=kube-state-metrics
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: infra
+
+---

--- a/lib/infra/17-cadvisor.yml
+++ b/lib/infra/17-cadvisor.yml
@@ -1,0 +1,67 @@
+# From: https://github.com/google/cadvisor/blob/master/deploy/kubernetes/base
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cadvisor
+  namespace: infra
+  annotations:
+    seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+spec:
+  selector:
+    matchLabels:
+      cadvisor: cadvisor
+  template:
+    metadata:
+      labels:
+        cadvisor: cadvisor
+    spec:
+      containers:
+      - name: cadvisor
+        image: k8s.gcr.io/cadvisor:v0.30.2
+        resources:
+          requests:
+            memory: 200Mi
+            cpu: 150m
+          limits:
+            cpu: 300m
+        volumeMounts:
+        - name: rootfs
+          mountPath: /rootfs
+          readOnly: true
+        - name: var-run
+          mountPath: /var/run
+          readOnly: true
+        - name: sys
+          mountPath: /sys
+          readOnly: true
+        - name: docker
+          mountPath: /var/lib/docker
+          readOnly: true
+        - name: disk
+          mountPath: /dev/disk
+          readOnly: true
+        ports:
+          - name: http
+            containerPort: 8080
+            protocol: TCP
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: rootfs
+        hostPath:
+          path: /
+      - name: var-run
+        hostPath:
+          path: /var/run
+      - name: sys
+        hostPath:
+          path: /sys
+      - name: docker
+        hostPath:
+          path: /var/lib/docker
+      - name: disk
+        hostPath:
+          path: /dev/disk
+---

--- a/lib/infra/18-node-exporter.yml
+++ b/lib/infra/18-node-exporter.yml
@@ -1,0 +1,133 @@
+# FROM: https://github.com/coreos/prometheus-operator/blob/master/contrib/kube-prometheus/manifests/
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: node-exporter
+  name: node-exporter
+  namespace: infra
+spec:
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 9100
+    targetPort: metrics
+  selector:
+    app: node-exporter
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-exporter
+  namespace: infra
+
+---
+apiVersion: apps/v1beta2
+kind: DaemonSet
+metadata:
+  labels:
+    app: node-exporter
+  name: node-exporter
+  namespace: infra
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+    spec:
+      containers:
+      - args:
+        - --web.listen-address=:9100
+        - --path.procfs=/host/proc
+        - --path.sysfs=/host/sys
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
+        - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
+        image: quay.io/prometheus/node-exporter:v0.16.0
+        name: node-exporter
+        ports:
+          - containerPort: 9100
+            hostPort: 9100
+            name: metrics
+        resources:
+          limits:
+            cpu: 102m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/proc
+          name: proc
+          readOnly: false
+        - mountPath: /host/sys
+          name: sys
+          readOnly: false
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: node-exporter
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      volumes:
+      - hostPath:
+          path: /proc
+        name: proc
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-exporter
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+    - ""
+  resources:
+    - pods
+  verbs: ["get", "list", "delete", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-exporter
+subjects:
+- kind: ServiceAccount
+  name: node-exporter
+  namespace: infra


### PR DESCRIPTION
tl;dr This adds alerts and more graphs.
- Alerts: https://infra.moov.io/prometheus/alerts (We can route these to Slack)
- Graphs: https://infra.moov.io/grafana/

kube-state-metrics is a kubernetes service which is designed to pick
up cluster stats. It's pretty common to see deployed.

Link: https://github.com/kubernetes/kube-state-metrics

kubernetes-monitoring is a Github org with some k8s and Prometheus
folks who are working on a good set of alerts and dashboards for k8s installs.

Link: https://github.com/kubernetes-monitoring/kubernetes-mixin

Example graphs: 

![nodes](https://user-images.githubusercontent.com/120951/46042506-67129d00-c0ca-11e8-9440-8e0b1c704e69.png)
![pods](https://user-images.githubusercontent.com/120951/46042507-67129d00-c0ca-11e8-91cb-c070b5f989a7.png)
