### PR TITLE
images/oauth2_proxy: compile code with Go 1.11.x instead of 1.8.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,5 @@ script:
   # Prometheus
   - promtool-configmap --version
   - promtool-configmap envs/sbx/infra/14-prometheus.yml
+  # Run infra tests
+  - make test

--- a/images/oauth2_proxy/Dockerfile
+++ b/images/oauth2_proxy/Dockerfile
@@ -1,9 +1,14 @@
-FROM alpine:latest as builder
-RUN apk add -U ca-certificates wget
-RUN wget -O oauth2_proxy.tar.gz https://github.com/bitly/oauth2_proxy/releases/download/v2.2/oauth2_proxy-2.2.0.linux-amd64.go1.8.1.tar.gz
-RUN tar xf oauth2_proxy.tar.gz
+FROM golang:1.11-stretch as builder
+WORKDIR /go/src/github.com/bitly/
+RUN apt-get update && apt-get install -y ca-certificates gcc g++ git make wget
+RUN git clone https://github.com/bitly/oauth2_proxy.git
+WORKDIR /go/src/github.com/bitly/oauth2_proxy
+RUN git checkout tags/v2.2 -b v2.2
+RUN git branch --set-upstream-to=origin/master v2.2
+RUN git log -n1
+RUN CGO_ENABLED=0 go get -u github.com/bitly/oauth2_proxy
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /oauth2_proxy-*/oauth2_proxy /bin/oauth2_proxy
+COPY --from=builder /go/bin/oauth2_proxy /bin/oauth2_proxy
 ENTRYPOINT ["/bin/oauth2_proxy"]

--- a/images/oauth2_proxy/makefile
+++ b/images/oauth2_proxy/makefile
@@ -1,4 +1,4 @@
-VERSION := v2.2
+VERSION := v2.2-moov1
 
 .PHONY: docker release
 

--- a/images/test.sh
+++ b/images/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+FILES=$(find ./images/ -maxdepth 2 -mindepth 2 -type f -name Dockerfile)
+for dockerfile in "${FILES[@]}";
+do
+    cd `dirname "$dockerfile"`
+    make docker
+    if [ -f "test.sh" ];
+    then
+        exec ./test.sh
+    fi
+    cd -
+done

--- a/makefile
+++ b/makefile
@@ -1,8 +1,13 @@
-release: AUTHORS
-
 # From https://github.com/genuinetools/img
 .PHONY: AUTHORS
 AUTHORS:
 	@$(file >$@,# This file lists all individuals having contributed content to the repository.)
 	@$(file >>$@,# For how it is generated, see `make AUTHORS`.)
 	@echo "$(shell git log --format='\n%aN <%aE>' | LC_ALL=C.UTF-8 sort -uf)" >> $@
+
+release: AUTHORS
+
+.PHONY: test
+test:
+# Test our docker images
+	@./images/test.sh


### PR DESCRIPTION
Go 1.8 is pretty old (Feb '17), so we should use a more modern Go. Doubly so because this is exposed to the public internet. 

Issue: https://github.com/moov-io/infra/issues/25