### PR TITLE
images/tarsnap: fixup image build failure

### DIFF
--- a/cmd/dockertest/main.go
+++ b/cmd/dockertest/main.go
@@ -87,23 +87,20 @@ type tester struct {
 func (t *tester) run(name string, parent string) {
 	defer t.wg.Done()
 
-	log.Printf("Running %s tests", name)
+	log.Printf("building docker image and running %s tests", name)
 
-	var buf bytes.Buffer
 	cmd := exec.Command("make", "docker")
 	cmd.Dir = filepath.Join(parent, name)
-	cmd.Stderr = &buf
-	cmd.Stderr = &buf
-	err := cmd.Run()
+	bs, err := cmd.CombinedOutput()
 
 	if *flagVerbose || err != nil {
-		fmt.Printf("\n%s docker build output:\n%s\n\n", name, buf.String())
+		fmt.Printf("\n%s docker build output:\n%s\n\n", name, string(bs))
 	}
 	if err != nil {
 		err = fmt.Errorf("ERROR running %s tests: %v", name, err)
 		t.errors = append(t.errors, err)
 		log.Println(err.Error())
 	} else {
-		log.Printf("%s tests passed", name)
+		log.Printf("%s image built and tests passed", name)
 	}
 }

--- a/images/tarsnap/Dockerfile
+++ b/images/tarsnap/Dockerfile
@@ -1,16 +1,16 @@
-FROM debian:jessie
+FROM debian:9
 
 # Docs: https://www.tarsnap.com/pkg-deb.html
 
-RUN apt-get update -qq && apt-get install -y ca-certificates wget
+RUN apt-get update -qq && apt-get install -y ca-certificates lsb-release gnupg2 wget
 RUN wget https://pkg.tarsnap.com/tarsnap-deb-packaging-key.asc
 
 # To verify this key, run:
 # gpg --list-packets tarsnap-deb-packaging-key.asc | grep signature
 
 RUN apt-key add tarsnap-deb-packaging-key.asc
-RUN echo "deb http://pkg.tarsnap.com/deb/jessie ./" | tee -a /etc/apt/sources.list.d/tarsnap.list
-RUN apt-get update -qq && apt-get install -y tarsnap
+RUN echo "deb http://pkg.tarsnap.com/deb/$(lsb_release -s -c) ./" | tee -a /etc/apt/sources.list.d/tarsnap.list
+RUN apt-get update -qq && apt-get install -y tarsnap # tarsnap-archive-keyring # libssl
 
 USER backup
 RUN tarsnap --version


### PR DESCRIPTION
Also, 

```
cmd/dockertest: show docker build output on failure

Previously we would overwrite stderr/stdout because of a shared bytes.Buffer. 
CombinedOutput properly joins the two streams for us.
```