### PR TITLE
images/fsftp: quick docker image for FTP server in a docker image

### DIFF
--- a/images/fsftp/Dockerfile
+++ b/images/fsftp/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.12-alpine as builder
+RUN apk add -U git
+WORKDIR /go/src/github.com/goftp
+RUN git clone https://github.com/goftp/server.git
+WORKDIR /go/src/github.com/goftp/server
+ENV CGO_ENABLED=0
+RUN go get -u ./...
+RUN go build -o /go/bin/fsftp github.com/goftp/server/exampleftpd
+
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /go/bin/fsftp /bin/fsftp
+EXPOSE 2121
+ENTRYPOINT ["/bin/fsftp"]

--- a/images/fsftp/README.md
+++ b/images/fsftp/README.md
@@ -1,0 +1,20 @@
+## moov/fsftp
+
+**NOTE**: This Docker is **not** designed for production use. Please use a production grade FTP server!
+
+`moov/fsftp` is a Docker image for running an FTP server from with a filesystem backed. We bundle this in an image because the same test library is used in some of our applications.
+
+```
+$ docker run moov/fsftp:v0.1.0 -help
+Usage of /bin/fsftp:
+  -host string
+    	Port (default "localhost")
+  -pass string
+    	Password for login (default "123456")
+  -port int
+    	Port (default 2121)
+  -root string
+    	Root directory to serve
+  -user string
+    	Username for login (default "admin")
+```

--- a/images/fsftp/makefile
+++ b/images/fsftp/makefile
@@ -1,0 +1,10 @@
+VERSION := v0.1.0
+
+.PHONY: docker release
+
+docker:
+	docker build --pull -t moov/fsftp:$(VERSION) .
+	docker tag moov/fsftp:$(VERSION) moov/fsftp:latest
+
+release:
+	docker push moov/fsftp:$(VERSION)


### PR DESCRIPTION
I'm going to use this image in local dev and dev environments to serve as an FTP server for paygate to interact with.

Issue: https://github.com/moov-io/paygate/issues/88