### PR TITLE
images/tarsnap: upgrade to Debian 10

### DIFF
--- a/images/tarsnap/Dockerfile
+++ b/images/tarsnap/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9
+FROM debian:10
 
 # Docs: https://www.tarsnap.com/pkg-deb.html
 


### PR DESCRIPTION
See: https://golang.org/doc/go1.13