### PR TITLE
envs/oss: add local.moov.io or local dev

### DIFF
--- a/envs/oss/moov.io.tf
+++ b/envs/oss/moov.io.tf
@@ -124,6 +124,15 @@ resource "google_dns_record_set" "infra" {
   rrdatas = [data.kubernetes_service.traefik.load_balancer_ingress[0].ip]
 }
 
+resource "google_dns_record_set" "local" {
+  name         = "local.${google_dns_managed_zone.moov-io.dns_name}"
+  managed_zone = google_dns_managed_zone.moov-io.name
+  type         = "A"
+  ttl          = 60
+
+  rrdatas = ["127.0.0.1"]
+}
+
 resource "google_dns_record_set" "slack" {
   name         = "slack.${google_dns_managed_zone.moov-io.dns_name}"
   managed_zone = google_dns_managed_zone.moov-io.name


### PR DESCRIPTION
```hcl
Terraform will perform the following actions:

  # google_dns_record_set.local will be created
  + resource "google_dns_record_set" "local" {
      + id           = (known after apply)
      + managed_zone = "moov-io"
      + name         = "local.moov.io."
      + project      = (known after apply)
      + rrdatas      = [
          + "127.0.0.1",
        ]
      + ttl          = 60
      + type         = "A"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```