### PR TITLE
modules/customers: support secrets for transit and mysql configs

### DIFF
--- a/modules/customers/deployment.tf
+++ b/modules/customers/deployment.tf
@@ -79,41 +79,33 @@ resource "kubernetes_deployment" "customers" {
           }
           env {
             name = "DATABASE_TYPE"
-            value = "sqlite"
+            value = var.database_type
           }
-          # env {
-          #   name: DATABASE_TYPE
-          #   value: mysql
-          # }
           env {
             name = "SQLITE_DB_PATH"
-            value = "/opt/moov/customers/customers.db"
+            value = var.sqlite_db_path
           }
-          # env {
-          #   name: MYSQL_ADDRESS
-          #   value: 'tcp(customers-mysql.apps.svc.cluster.local:3306)'
-          # }
-          # env {
-          #   name: MYSQL_DATABASE
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: customers-mysql-secrets
-          #       key: database
-          # }
-          # env {
-          #   name: MYSQL_USER
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: customers-mysql-secrets
-          #       key: username
-          # }
-          # env {
-          #   name: MYSQL_PASSWORD
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: customers-mysql-secrets
-          #       key: password
-          # }
+          env {
+            name = "MYSQL_ADDRESS"
+            value = var.mysql_address
+          }
+          env {
+            name = "MYSQL_DATABASE"
+            value = var.mysql_database
+          }
+          env {
+            name = "MYSQL_USER"
+            value = var.mysql_username
+          }
+          env {
+            name = "MYSQL_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = "customers-mysql-secrets"
+                key = "password"
+              }
+            }
+          }
           volume_mount {
             name = "customers"
             mount_path = "/opt/moov/customers/"

--- a/modules/customers/deployment.tf
+++ b/modules/customers/deployment.tf
@@ -58,7 +58,12 @@ resource "kubernetes_deployment" "customers" {
           }
           env {
             name = "TRANSIT_LOCAL_BASE64_KEY"
-            value = var.transit_local_base64_key
+            value_from {
+              secret_key_ref {
+                name = "customers-transit-secrets"
+                key = "transit-local-base64-key"
+              }
+            }
           }
           env {
             name = "CLOUD_PROVIDER"

--- a/modules/customers/secrets.tf
+++ b/modules/customers/secrets.tf
@@ -1,0 +1,10 @@
+resource "kubernetes_secret" "customers-transit-secrets" {
+  metadata {
+    name = "customers-transit-secrets"
+    namespace = var.namespace
+  }
+
+  data = {
+    "transit-local-base64-key" = "${file(var.transit_local_base64_key_filepath)}"
+  }
+}

--- a/modules/customers/secrets.tf
+++ b/modules/customers/secrets.tf
@@ -16,6 +16,6 @@ resource "kubernetes_secret" "customers-mysql-secrets" {
   }
 
   data = {
-    "password" = "${fileexists(var.mysql_password_filepath) ? var.mysql_password_filepath : ""}"
+    "password" = "${fileexists(var.mysql_password_filepath) ? trimspace(file(var.mysql_password_filepath)) : ""}"
   }
 }

--- a/modules/customers/secrets.tf
+++ b/modules/customers/secrets.tf
@@ -8,3 +8,14 @@ resource "kubernetes_secret" "customers-transit-secrets" {
     "transit-local-base64-key" = "${file(var.transit_local_base64_key_filepath)}"
   }
 }
+
+resource "kubernetes_secret" "customers-mysql-secrets" {
+  metadata {
+    name = "customers-mysql-secrets"
+    namespace = var.namespace
+  }
+
+  data = {
+    "password" = "${fileexists(var.mysql_password_filepath) ? var.mysql_password_filepath : ""}"
+  }
+}

--- a/modules/customers/variables.tf
+++ b/modules/customers/variables.tf
@@ -25,3 +25,22 @@ variable "capacity" {
 }
 
 variable "transit_local_base64_key_filepath" {}
+
+variable "database_type" {
+  default = "sqlite"
+}
+
+variable "sqlite_db_path" {
+  default = "/opt/moov/customers/customers.db"
+}
+
+variable "mysql_address" {
+  default = "tcp(mysql:3306)"
+}
+variable "mysql_database" {
+  default = "customers"
+}
+variable "mysql_username" {
+  default = "customers"
+}
+variable "mysql_password_filepath" {}

--- a/modules/customers/variables.tf
+++ b/modules/customers/variables.tf
@@ -24,6 +24,4 @@ variable "capacity" {
   default = "1Gi"
 }
 
-variable "transit_local_base64_key" {
-  default = ""
-}
+variable "transit_local_base64_key_filepath" {}


### PR DESCRIPTION
This adds support for configuring MySQL in Customers and hiding the transit encryption key with a Secret. 