### PR TITLE
Ignore nancy version checks

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -136,6 +136,10 @@ if [[ "$OS_NAME" != "windows" ]]; then
     # Clean nancy cache
     ./bin/nancy --clean-cache
 
+    # Skip Nancy version check
+    mkdir -p ~/.ossindex/.nancy-config
+    echo "last_update_check: "$(date "+%Y-%m-%d") > ~/.ossindex/.nancy-config/update_check.yml
+
     # Ignore Consul and Vault Enterprise, they need a gocloud.dev release
     go list -mod=mod -m all | ./bin/nancy sleuth --exclude-vulnerability "$ignored"
 

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -103,8 +103,8 @@ if [[ "$OS_NAME" != "windows" ]]; then
 fi
 
 # nancy (vulnerable dependencies)
-if [[ "$OS_NAME" == "linux" ]]; then wget -q -O ./bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.9/nancy-v1.0.9-linux-amd64; fi
-if [[ "$OS_NAME" == "osx" ]]; then wget -q -O ./bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.9/nancy-v1.0.9-darwin-amd64; fi
+if [[ "$OS_NAME" == "linux" ]]; then wget -q -O ./bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.10/nancy-v1.0.10-linux-amd64; fi
+if [[ "$OS_NAME" == "osx" ]]; then wget -q -O ./bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.10/nancy-v1.0.10-darwin-amd64; fi
 if [[ "$OS_NAME" != "windows" ]]; then
     chmod +x ./bin/nancy
     ./bin/nancy --version


### PR DESCRIPTION
We can write a timestamp that will cause nancy to skip the version
check against GitHub. This call gets ratelimited quickly across all of
the Actions runners.

Example: https://github.com/moov-io/ach/runs/1816420912
![image](https://user-images.githubusercontent.com/120951/106644806-6d3da180-6540-11eb-8067-891a18f36c8d.png)

See: https://github.com/sonatype-nexus-community/nancy/blob/v1.0.10/README.md#big-ci-note