### PR TITLE
go/lint: reject moovfinancial dependencies in go.mod files

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -39,6 +39,18 @@ if [[ "$OS_NAME" != "windows" ]]; then
     echo "finished gofmt check"
 fi
 
+# Reject moovfinancial dependencies in moov-io projects
+org=$(basename $(dirname $(pwd)))
+if [[ "$org" == "moov-io" ]];
+then
+    # Fail our build if we find moovfinancial dependencies
+    if go list -m all | grep moovfinancial;
+    then
+        echo "Found github.com/moovfinancial dependencies in OSS. Please remove"
+        exit 1
+    fi
+fi
+
 # Misspell
 if [[ "$OS_NAME" == "linux" ]]; then wget -q -O misspell.tar.gz https://github.com/client9/misspell/releases/download/v0.3.4/misspell_0.3.4_linux_64bit.tar.gz; fi
 if [[ "$OS_NAME" == "osx" ]]; then wget -q -O misspell.tar.gz https://github.com/client9/misspell/releases/download/v0.3.4/misspell_0.3.4_mac_64bit.tar.gz; fi


### PR DESCRIPTION
In a team's standup today it came up that we need to inspect builds for a specific dependency and ensure always on the latest available. This reminded me that we need to reject moovfinancial dependencies in moov-io projects. 