### PR TITLE
modules/kube-state-metrics: add missing RBAC rule for additional deployments apiGroup

### DIFF
--- a/modules/kube-state-metrics/rbac.tf
+++ b/modules/kube-state-metrics/rbac.tf
@@ -32,7 +32,7 @@ resource "kubernetes_cluster_role" "kube-state-metrics" {
       "replicasets",
       "ingresses",
     ]
-    verbs = ["list", "watch"]
+    verbs = ["get", "list", "watch"]
   }
   rule {
     api_groups = ["apps"]
@@ -41,6 +41,13 @@ resource "kubernetes_cluster_role" "kube-state-metrics" {
       "daemonsets",
       "deployments",
       "replicasets",
+    ]
+    verbs = ["list", "watch"]
+  }
+  rule {
+    api_groups = ["extensions", "apps"]
+    resources = [
+      "deployments",
     ]
     verbs = ["list", "watch"]
   }


### PR DESCRIPTION
Found this when looking at logs today. 

![Screen Shot 2021-02-23 at 11 26 47 AM](https://user-images.githubusercontent.com/120951/108914151-cba9ed00-75df-11eb-803e-e1758a61bfd5.png)
