### PR TITLE
infra/node-exporter: upgrade v1.0.1 to v1.1.1

### DIFF
--- a/lib/infra/18-node-exporter.yml
+++ b/lib/infra/18-node-exporter.yml
@@ -48,7 +48,7 @@ spec:
         - --path.sysfs=/host/sys
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
         - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
-        image: quay.io/prometheus/node-exporter:v1.0.1
+        image: quay.io/prometheus/node-exporter:v1.1.1
         name: node-exporter
         ports:
           - containerPort: 9100

--- a/modules/node-exporter/variables.tf
+++ b/modules/node-exporter/variables.tf
@@ -5,7 +5,7 @@ variable "instances" {
 }
 
 variable "image_tag" {
-  default = "v1.0.1"
+  default = "v1.1.1"
 }
 
 ## Default Resource Allocation


### PR DESCRIPTION
New version available of Prometheus Node Exporter. See the [v1.1.1 tag](https://quay.io/repository/prometheus/node-exporter?tab=tags). There don't seem to be any breaking changes regarding config, etc. in the two interceding release docs ([v1.1.0](https://github.com/prometheus/node_exporter/releases/tag/v1.1.0), [v1.1.1](https://github.com/prometheus/node_exporter/releases/tag/v1.1.1)) so we should be good to bump.

This change was applied and checked in a staging environment:

```
~ image                      = "quay.io/prometheus/node-exporter:v1.0.1" -> "quay.io/prometheus/node-exporter:v1.1.1
Apply complete!
```