### PR TITLE
go/lint: upgrade nancy from v1.0.12 to v1.0.15

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -129,8 +129,8 @@ if [[ "$OS_NAME" != "windows" ]]; then
 fi
 
 # nancy (vulnerable dependencies)
-if [[ "$OS_NAME" == "linux" ]]; then wget -q -O ./bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.12/nancy-v1.0.12-linux-amd64; fi
-if [[ "$OS_NAME" == "osx" ]]; then wget -q -O ./bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.12/nancy-v1.0.12-darwin-amd64; fi
+if [[ "$OS_NAME" == "linux" ]]; then wget -q -O ./bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.15/nancy-v1.0.15-linux-amd64; fi
+if [[ "$OS_NAME" == "osx" ]]; then wget -q -O ./bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.15/nancy-v1.0.15-darwin-amd64; fi
 if [[ "$OS_NAME" != "windows" ]]; then
     chmod +x ./bin/nancy
     ./bin/nancy --version


### PR DESCRIPTION
Upgrade nancy. Checked release notes for interceding versions [1.0.13](https://github.com/sonatype-nexus-community/nancy/releases/tag/v1.0.13), [1.0.14,](https://github.com/sonatype-nexus-community/nancy/releases/tag/v1.0.14) and [1.0.15](https://github.com/sonatype-nexus-community/nancy/releases/tag/v1.0.15) and nothing seemed breaking. Ran locally:

```
$ ./go/lint-project.sh
# ...
nancy version 1.0.15
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Summary                      ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━┫
┃ Audited Dependencies    ┃ 24 ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━┫
┃ Vulnerable Dependencies ┃ 0  ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━┛

finished nancy check
# ...
```