### PR TITLE
go/lint: upgrade staticcheck from 2020.2.1 to 2020.2.2

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -113,8 +113,8 @@ if [[ "$EXPERIMENTAL" == *"gitleaks"* ]]; then
 fi
 
 # staticcheck
-if [[ "$OS_NAME" == "linux" ]]; then wget -q -O staticcheck.tar.gz https://github.com/dominikh/go-tools/releases/download/2020.2.1/staticcheck_linux_amd64.tar.gz; fi
-if [[ "$OS_NAME" == "osx" ]]; then wget -q -O staticcheck.tar.gz https://github.com/dominikh/go-tools/releases/download/2020.2.1/staticcheck_darwin_amd64.tar.gz; fi
+if [[ "$OS_NAME" == "linux" ]]; then wget -q -O staticcheck.tar.gz https://github.com/dominikh/go-tools/releases/download/2020.2.2/staticcheck_linux_amd64.tar.gz; fi
+if [[ "$OS_NAME" == "osx" ]]; then wget -q -O staticcheck.tar.gz https://github.com/dominikh/go-tools/releases/download/2020.2.2/staticcheck_darwin_amd64.tar.gz; fi
 if [[ "$OS_NAME" != "windows" ]]; then
     tar xf staticcheck.tar.gz
     cp ./staticcheck/staticcheck ./bin/staticcheck


### PR DESCRIPTION
Upgrade staticcheck. [No breaking changes](https://staticcheck.io/changes/2020.2#2020.2.2) and local run works fine:

```
project.sh
staticcheck 2020.2.2 (v0.1.2)
finished staticcheck check
```