### PR TITLE
go/lint: upgrade golangci-lint from 1.36.0 to 1.37.1

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -173,7 +173,7 @@ fi
 
 # golangci-lint
 if [[ "$OS_NAME" != "windows" ]]; then
-    wget -q -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.36.0
+    wget -q -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.37.1
 
     enabled="-E=bodyclose,exhaustive,rowserrcheck"
     if [ -n "$GOLANGCI_LINTERS" ];


### PR DESCRIPTION
Upgrade golangci-lint. [No breaking changes](https://github.com/golangci/golangci-lint/releases/). Successful local run:

```
% ./go/lint-project.sh
# ...
golangci/golangci-lint info checking GitHub for tag 'v1.37.1'
golangci/golangci-lint info found version: 1.37.1 for v1.37.1/darwin/amd64
golangci/golangci-lint info installed ./bin/golangci-lint
golangci-lint has version 1.37.1 built from b39dbcd6 on 2021-02-20T11:48:06Z
finished golangci-lint check
# ...
```