### PR TITLE
infra/cadvisor: Upgrade from v0.37.0 to v0.37.5

### DIFF
--- a/modules/cadvisor/variables.tf
+++ b/modules/cadvisor/variables.tf
@@ -5,7 +5,7 @@ variable "instances" {
 }
 
 variable "docker_image" {
-  default = "gcr.io/cadvisor/cadvisor:v0.37.0"
+  default = "gcr.io/cadvisor/cadvisor:v0.37.5"
 }
 
 ## Default Resource Allocation


### PR DESCRIPTION
[No breaking changes](https://github.com/google/cadvisor/releases/).