### PR TITLE
envs/oss: upgrade kubernetes-cloud-mysql-backup from v2.3.0 to v2.5.0

### DIFF
--- a/lib/apps/12-paygate-mysql.yml
+++ b/lib/apps/12-paygate-mysql.yml
@@ -175,7 +175,7 @@ spec:
       template:
         spec:
           containers:
-            - image: gcr.io/maynard-io-public/kubernetes-cloud-mysql-backup:v2.3.0
+            - image: gcr.io/maynard-io-public/kubernetes-cloud-mysql-backup:v2.5.0
               name: backup
               imagePullPolicy: Always
               env:

--- a/lib/apps/13-watchman-mysql.yml
+++ b/lib/apps/13-watchman-mysql.yml
@@ -176,7 +176,7 @@ spec:
       template:
         spec:
           containers:
-            - image: gcr.io/maynard-io-public/kubernetes-cloud-mysql-backup:v2.3.0
+            - image: gcr.io/maynard-io-public/kubernetes-cloud-mysql-backup:v2.5.0
               imagePullPolicy: Always
               name: backup
               env:

--- a/lib/apps/16-customers-mysql.yml
+++ b/lib/apps/16-customers-mysql.yml
@@ -176,7 +176,7 @@ spec:
       template:
         spec:
           containers:
-            - image: gcr.io/maynard-io-public/kubernetes-cloud-mysql-backup:v2.3.0
+            - image: gcr.io/maynard-io-public/kubernetes-cloud-mysql-backup:v2.5.0
               name: backup
               env:
                 - name: GCP_GCLOUD_AUTH


### PR DESCRIPTION
Bump cloud-mysql-backup version in OSS environment. paygate and customers don't seem to have mysql-backup deployed but I upgraded the tag in those YAMLs as well.

```
% kubectl diff -f ../../lib/apps/13-watchman-mysql.yml 
# ...
@@ -73,7 +73,7 @@
-            image: adamdecaf/mysql-backup:2020-07-09-01
+            image: gcr.io/maynard-io-public/kubernetes-cloud-mysql-backup:v2.5.0
# ...
```

Will ```kubectl apply -f``` for the watchman backup cronjob once this is approved.