### PR TITLE
infra/oauth2-proxy: Upgrade from v6.1.1 to v7.0.1

### DIFF
--- a/modules/oauth2-proxy/variables.tf
+++ b/modules/oauth2-proxy/variables.tf
@@ -5,7 +5,7 @@ variable "instances" {
 }
 
 variable "image_tag" {
-  default = "v6.1.1"
+  default = "v7.0.1"
 }
 
 variable "client_id_filepath" {}


### PR DESCRIPTION
[Breaking changes](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.0.0). I didn't see any that apply to us as far as config goes but only one way to find out...