### PR TITLE
infra/prometheus: Upgrade from v2.24.1 to v2.25.0

### DIFF
--- a/lib/infra/14-prometheus.yml
+++ b/lib/infra/14-prometheus.yml
@@ -214,7 +214,7 @@ spec:
       #     value: "true"
       #     effect: NoSchedule
       containers:
-      - image: prom/prometheus:v2.24.1
+      - image: prom/prometheus:v2.25.0
         imagePullPolicy: Always
         name: prometheus
         args:

--- a/modules/prometheus/variables.tf
+++ b/modules/prometheus/variables.tf
@@ -5,7 +5,7 @@ variable "instances" {
 }
 
 variable "image_tag" {
-  default = "v2.24.1"
+  default = "v2.25.0"
 }
 
 variable "config_filepath" {}


### PR DESCRIPTION
[Release notes; no breaking changes.](https://github.com/prometheus/prometheus/releases) Will apply changes to OSS environment once this is merged.

```
% kubectl diff -f ./infra/14-prometheus.yml
# ...
-        image: prom/prometheus:v2.24.1
+        image: prom/prometheus:v2.25.0
# ...
```