### PR TITLE
modules/traefik: Change deployment to use Recreate strategy

### DIFF
--- a/modules/traefik/deployment.tf
+++ b/modules/traefik/deployment.tf
@@ -8,6 +8,9 @@ resource "kubernetes_deployment" "traefik" {
   }
   spec {
     replicas = var.instances
+    strategy {
+      type = "Recreate"
+    }
     selector {
       match_labels = {
         app = "traefik"


### PR DESCRIPTION


With the current configuration Traefik deployments will result in new pods being stuck in `ContainerCreating`:

```
Warning  FailedAttachVolume  4m46s  attachdetach-controller  Multi-Attach error for volume "pvc-[redacted]" Volume is already used by pod(s) traefik-[redacted]
```

Scaling the old ReplicaSet to 0 or scaling the deployment to 0 then re-applying via `terraform` solves the issue as it frees the pvc in question up for use by the new pod. The change of deployment strategy to [Recreate](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#recreate-deployment) accomplishes this idiomatically.