### PR TITLE
modules/cadvisor: Make container privileged to allow access to OOM events

### DIFF
--- a/modules/cadvisor/daemonset.tf
+++ b/modules/cadvisor/daemonset.tf
@@ -27,6 +27,9 @@ resource "kubernetes_daemonset" "cadvisor" {
         service_account_name = "cadvisor"
         automount_service_account_token = false
         container {
+          security_context {
+            privileged = true
+          }
           image = var.docker_image
           image_pull_policy = "Always"
           name = "cadvisor"


### PR DESCRIPTION
See https://github.com/moov-io/infra/pull/173#issuecomment-786783315. / was already mounted and matched the default configuration generated by [running kustomize from the cadvisor repo](https://github.com/google/cadvisor/tree/master/deploy/kubernetes). This change makes the container privileged and fixes the error. No logs are generated and the container now has access to /dev/kmsg (as verified by getting shell inside of it and `tail`ing it).