### PR TITLE
modules/traefik: Revert to Rolling strategy with maxUnavailable = replicas

### DIFF
--- a/modules/traefik/deployment.tf
+++ b/modules/traefik/deployment.tf
@@ -9,7 +9,10 @@ resource "kubernetes_deployment" "traefik" {
   spec {
     replicas = var.instances
     strategy {
-      type = "Recreate"
+      rolling_update {
+        max_unavailable = 1
+        max_surge = 0
+      }
     }
     selector {
       match_labels = {


### PR DESCRIPTION
Paygate is configured as follows:

```
strategy {
      rolling_update {
        max_unavailable = 1
      }
    }
```

... and it destroys all pods before scheduling new ones. I applied this to traefik with the change that max_unavailable is set to `var.replicas` for the case that we have more than one someday.