### PR TITLE
Upgrade nancy and staticcheck

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -131,8 +131,8 @@ if [[ "$OS_NAME" != "windows" ]]; then
 fi
 
 # nancy (vulnerable dependencies)
-if [[ "$OS_NAME" == "linux" ]]; then wget -q -O ./bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.15/nancy-v1.0.15-linux-amd64; fi
-if [[ "$OS_NAME" == "osx" ]]; then wget -q -O ./bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.15/nancy-v1.0.15-darwin-amd64; fi
+if [[ "$OS_NAME" == "linux" ]]; then wget -q -O ./bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.17/nancy-v1.0.17-linux-amd64; fi
+if [[ "$OS_NAME" == "osx" ]]; then wget -q -O ./bin/nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.17/nancy-v1.0.17-darwin-amd64; fi
 if [[ "$OS_NAME" != "windows" ]]; then
     chmod +x ./bin/nancy
     ./bin/nancy --version

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -113,8 +113,8 @@ if [[ "$EXPERIMENTAL" == *"gitleaks"* ]]; then
 fi
 
 # staticcheck
-if [[ "$OS_NAME" == "linux" ]]; then wget -q -O staticcheck.tar.gz https://github.com/dominikh/go-tools/releases/download/2020.2.2/staticcheck_linux_amd64.tar.gz; fi
-if [[ "$OS_NAME" == "osx" ]]; then wget -q -O staticcheck.tar.gz https://github.com/dominikh/go-tools/releases/download/2020.2.2/staticcheck_darwin_amd64.tar.gz; fi
+if [[ "$OS_NAME" == "linux" ]]; then wget -q -O staticcheck.tar.gz https://github.com/dominikh/go-tools/releases/download/2020.2.3/staticcheck_linux_amd64.tar.gz; fi
+if [[ "$OS_NAME" == "osx" ]]; then wget -q -O staticcheck.tar.gz https://github.com/dominikh/go-tools/releases/download/2020.2.3/staticcheck_darwin_amd64.tar.gz; fi
 if [[ "$OS_NAME" != "windows" ]]; then
     tar xf staticcheck.tar.gz
     cp ./staticcheck/staticcheck ./bin/staticcheck


### PR DESCRIPTION
Two one-liners. Local run:

```
running go linters for osx
finished gofmt check
misspell version: 0.3.4
finished misspell check
staticcheck 2020.2.3 (v0.1.3)
finished staticcheck check
nancy version 1.0.17
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Summary                      ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━┫
┃ Audited Dependencies    ┃ 24 ┃
┣━━━━━━━━━━━━━━━━━━━━━━━━━╋━━━━┫
┃ Vulnerable Dependencies ┃ 0  ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━┻━━━━┛

finished nancy check
golangci/golangci-lint info checking GitHub for tag 'v1.37.1'
golangci/golangci-lint info found version: 1.37.1 for v1.37.1/darwin/amd64
golangci/golangci-lint info installed ./bin/golangci-lint
golangci-lint has version 1.37.1 built from b39dbcd6 on 2021-02-20T11:48:06Z
finished golangci-lint check
finished gocyclo check
?       github.com/moov-io/infra        [no test files]
?       github.com/moov-io/infra/cmd/dockertest [no test files]
?       github.com/moov-io/infra/cmd/kubernetes-mixins  [no test files]
?       github.com/moov-io/infra/images/fsftp   [no test files]
ok      github.com/moov-io/infra/pkg/gofuzz     0.090s  coverage: 86.2% of statements
```