### PR TITLE
Update lint-project.sh

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -151,6 +151,8 @@ if [[ "$OS_NAME" != "windows" ]]; then
         CVE-2020-15114
         CVE-2020-15115
         CVE-2020-15136
+        # github.com/gogo/protobuf (used by Viper and Go Kit)
+        CVE-2021-3121
     )
     ignored=$(printf ",%s" "${ignored_deps[@]}")
     ignored=${ignored:1}


### PR DESCRIPTION
Our CI fails because of [CVE-2021-3121] in gogo/protobuf, which is a dependency in Viper -> Prometheus common -> Go Kit -> ...

There is a 3 month old PR in viper: spf13/viper#1066

Viper is used to read configs, maybe it's safe to ignore it.