### PR TITLE
go/lint: specify nancy flags properly

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -48,7 +48,7 @@ if [[ "$OS_NAME" != "windows" ]]; then
     echo "finished gofmt check"
 fi
 
-# Would be set to 'moo-io' or 'moovfinancial'
+# Would be set to 'moov-io' or 'moovfinancial'
 org=$(go mod why | head -n1  | awk -F'/' '{print $2}')
 
 # Reject moovfinancial dependencies in moov-io projects
@@ -74,7 +74,6 @@ then
       exit 1
   fi
 fi
-
 
 # Misspell
 if [[ "$OS_NAME" == "linux" ]]; then wget -q -O misspell.tar.gz https://github.com/client9/misspell/releases/download/v0.3.4/misspell_0.3.4_linux_64bit.tar.gz; fi
@@ -158,7 +157,7 @@ if [[ "$OS_NAME" != "windows" ]]; then
     ./bin/nancy --clean-cache
 
     # Ignore Consul and Vault Enterprise, they need a gocloud.dev release
-    go list -mod=mod -m all | ./bin/nancy sleuth --skip-update-check --exclude-vulnerability "$ignored"
+    go list -mod=mod -m all | ./bin/nancy --skip-update-check --loud sleuth --exclude-vulnerability "$ignored"
 
     echo "" # newline
     echo "finished nancy check"


### PR DESCRIPTION
Dunno if this will work as I've had errors when moving flags before the sub-command, but their code reads like this will work.

https://github.com/sonatype-nexus-community/nancy/blob/533b797f2a7c14d2c9306785e8a92b3c66d41c46/internal/cmd/root.go#L194

We could also set `SKIP_UPDATE_CHECK=true` in the linter script.
https://github.com/sonatype-nexus-community/go-sona-types/blob/main/configuration/set.go#L237