### PR TITLE
go/lint: move off of deprecated goreleaser script

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -143,7 +143,7 @@ fi
 
 # golangci-lint
 if [[ "$OS_NAME" != "windows" ]]; then
-    wget -q -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.42.1
+    wget -q -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.42.1
 
     enabled="-E=asciicheck,bodyclose,exhaustive,gocyclo,misspell,rowserrcheck"
     if [ -n "$GOLANGCI_LINTERS" ];


### PR DESCRIPTION
Right now we're seeing the following deprecation warning

```
golangci/golangci-lint info checking GitHub for tag 'v1.42.1'
golangci/golangci-lint info found version: 1.42.1 for v1.42.1/linux/amd64
golangci/golangci-lint info installed ./bin/golangci-lint
golangci/golangci-lint err this script is deprecated, please do not use it anymore. check https://github.com/goreleaser/godownloader/issues/207
golangci-lint has version 1.42.1 built from 54f4301d on 2021-09-06T17:05:10Z
```