### PR TITLE
go/lint: update golangci-lint to v1.43.0 and enable bidichk

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -143,9 +143,9 @@ fi
 
 # golangci-lint
 if [[ "$OS_NAME" != "windows" ]]; then
-    wget -q -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.42.1
+    wget -q -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.43.0
 
-    enabled="-E=asciicheck,bodyclose,exhaustive,gocyclo,misspell,rowserrcheck"
+    enabled="-E=asciicheck,bidichk,bodyclose,exhaustive,gocyclo,misspell,rowserrcheck"
     if [ -n "$GOLANGCI_LINTERS" ];
     then
         enabled="$enabled"",$GOLANGCI_LINTERS"


### PR DESCRIPTION
Release notes: https://github.com/golangci/golangci-lint/releases/tag/v1.43.0