### PR TITLE
go/lint: enable more linters by default

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -145,7 +145,7 @@ fi
 if [[ "$OS_NAME" != "windows" ]]; then
     wget -q -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.43.0
 
-    enabled="-E=asciicheck,bidichk,bodyclose,exhaustive,gocyclo,misspell,rowserrcheck"
+    enabled="-E=asciicheck,bidichk,bodyclose,exhaustive,gocyclo,gosec,misspell,rowserrcheck"
     if [ -n "$GOLANGCI_LINTERS" ];
     then
         enabled="$enabled"",$GOLANGCI_LINTERS"

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -145,7 +145,7 @@ fi
 if [[ "$OS_NAME" != "windows" ]]; then
     wget -q -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.43.0
 
-    enabled="-E=asciicheck,bidichk,bodyclose,exhaustive,gocyclo,gosec,misspell,rowserrcheck"
+    enabled="-E=asciicheck,bidichk,bodyclose,exhaustive,gocyclo,gosec,misspell,rowserrcheck,sqlclosecheck"
     if [ -n "$GOLANGCI_LINTERS" ];
     then
         enabled="$enabled"",$GOLANGCI_LINTERS"


### PR DESCRIPTION
This has been previously enabled on some repositories as an opt-in basis along with some required linters. However we are pushing to enable `gosec` on all repositories. 

To try this out for yourself modify your repository's Makefile:

```
GOLANGCI_LINTERS=gosec ./lint-project.sh
```

See: https://golangci-lint.run/usage/linters/ 