### PR TITLE
go/lint: update gitleaks to v8.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ coverage.txt
 /kubeval
 /kubeval-*.tar.gz
 
+/gitleaks.tar.gz
+
 /images/infra-idx/nginx/cache/
 /images/infra-idx/nginx/run/
 


### PR DESCRIPTION
Releases: https://github.com/zricethezav/gitleaks/releases 