### PR TITLE
go/lint: support profiling each package during testing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -39,6 +39,15 @@ jobs:
         COVER_THRESHOLD: 85.0
       run: make check
 
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: "go-tooling-reports.zip"
+        path: |
+          ./coverage.txt
+          ./**/mem.out
+          ./**/cpu.out
+
     - name: Tests
       run: make test
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ terraform.tfstate.backup*
 misspell*
 staticcheck*
 /bin/
+cpu.out
+mem.out
+/*.test
 /coverage.txt
 
 /kubeval

--- a/makefile
+++ b/makefile
@@ -2,7 +2,12 @@ PLATFORM=$(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 .PHONY: check
 check:
-	EXPERIMENTAL=gitleaks GOCYCLO_LIMIT=15 GOLANGCI_FLAGS="--exclude-use-default=false" ./go/lint-project.sh
+	EXPERIMENTAL=gitleaks \
+	GOCYCLO_LIMIT=15 \
+	GOLANGCI_FLAGS="--exclude-use-default=false" \
+	GOTEST_FLAGS='-test.shuffle=on' \
+	PROFILE_GOTEST='yes' \
+	./go/lint-project.sh
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
You can view reports with the following command:

```
go tool pprof gofuzz.test -web ./pkg/gofuzz/cpu.out
```