### PR TITLE
go/lint: find the coverage total with a better regex

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -211,7 +211,7 @@ fi
 if [[ "$COVER_THRESHOLD" != "" ]]; then
     if [[ -f coverage.txt && "$PROFILE_GOTEST" != "yes" ]];
     then
-        coveredStatements=$(go tool cover -func=coverage.txt | grep total | grep -Eo '[0-9]+\.[0-9]+')
+        coveredStatements=$(go tool cover -func=coverage.txt | grep -E '^total:' | grep -Eo '[0-9]+\.[0-9]+')
         maximumCoverage=100
     fi
 


### PR DESCRIPTION
We had a build with the follow result from grepping

```
github.com/moov/secret-project/pkg/summary.go:22:				Subtotal			100.0%
total:										(statements)			80.8%
```