### PR TITLE
go/lint: enable durationcheck and nolintlint

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -127,7 +127,7 @@ fi
 if [[ "$OS_NAME" != "windows" ]]; then
     wget -q -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.44.2
 
-    enabled="-E=asciicheck,bidichk,bodyclose,exhaustive,gocyclo,gosec,misspell,rowserrcheck,sqlclosecheck"
+    enabled="-E=asciicheck,bidichk,bodyclose,exhaustive,durationcheck,gocyclo,gosec,misspell,nolintlint,rowserrcheck,sqlclosecheck"
     if [ -n "$GOLANGCI_LINTERS" ];
     then
         enabled="$enabled"",$GOLANGCI_LINTERS"


### PR DESCRIPTION
- [durationcheck](https://github.com/charithe/durationcheck): "detect cases where two time.Duration values are being multiplied in possibly erroneous ways"
- [nolintlint](https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint/README.md): "find ill-formed or insufficiently explained // nolint directives for golangci"