### PR TITLE
go/lint: remove gocyclo linter

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -133,7 +133,7 @@ fi
 if [[ "$OS_NAME" != "windows" ]]; then
     wget -q -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.45.2
 
-    enabled="-E=asciicheck,bidichk,bodyclose,exhaustive,durationcheck,gocyclo,gosec,misspell,nolintlint,rowserrcheck,sqlclosecheck"
+    enabled="-E=asciicheck,bidichk,bodyclose,exhaustive,durationcheck,gosec,misspell,nolintlint,rowserrcheck,sqlclosecheck"
     if [ -n "$GOLANGCI_LINTERS" ];
     then
         enabled="$enabled"",$GOLANGCI_LINTERS"


### PR DESCRIPTION
There is a flag to configure this, but it's deprecated:
https://github.com/golangci/golangci-lint/blob/7bbbe77e5e68cdbecad5e25fc44810afd8f3d48c/pkg/commands/run.go#L154-L155

```
# set some golangci-linter passthrough options
if [[ $GOLANGCI_FLAGS == "" ]];
then
    GOLANGCI_FLAGS="--gocyclo.min-complexity=50"
fi
```

```
Flag --gocyclo.min-complexity has been deprecated, flag will be removed soon, please, use .golangci.yml config
```

So we should just remove this. Setting `.golangci.yml` isn't something I want moov-io/infra's script to deal with. 