### PR TITLE
go/lint: only pass deps in our final binary to nancy

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -117,7 +117,7 @@ if [[ "$OS_NAME" != "windows" ]]; then
     ./bin/nancy --clean-cache
 
     # Ignore Consul and Vault Enterprise, they need a gocloud.dev release
-    go list -mod=mod -m all | ./bin/nancy --skip-update-check --loud sleuth --exclude-vulnerability "$ignored"
+    go list -deps -f '{{with .Module}}{{.Path}} {{.Version}}{{end}}' ./... | ./bin/nancy --skip-update-check --loud sleuth --exclude-vulnerability "$ignored"
 
     echo "" # newline
     echo "finished nancy check"


### PR DESCRIPTION
This extends on the work from https://github.com/moov-io/infra/pull/251  (and https://github.com/sonatype-nexus-community/nancy/issues/228)

However, nancy requires the format of ".Path .Version" in the output, so we can force `go list` to output that. 
See: https://github.com/golang/go/issues/27900