### PR TITLE
go/lint: call full path for govulncheck, if found

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -165,9 +165,14 @@ then
     go install golang.org/x/vuln/cmd/govulncheck@latest
 
     # Run govulncheck
-    govulncheck -v -test ./...
-
-    echo "finished govulncheck check"
+    if [ -f /home/runner/go/bin/govulncheck ];
+    then
+        echo "starting govulncheck check"
+        /home/runner/go/bin/govulncheck -v -test ./...
+        echo "finished govulncheck check"
+    else
+        echo "Can't find govulncheck..."
+    fi
 fi
 
 # golangci-lint


### PR DESCRIPTION
Seeing failures: https://github.com/moov-io/wire/actions/runs/3004051492/attempts/1 