### PR TITLE
go/lint: enable more Go linters in golangci-lint

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -207,7 +207,7 @@ fi
 if [[ "$OS_NAME" != "windows" ]]; then
     wget -q -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s "$golangci_version"
 
-    enabled="-E=asciicheck,bidichk,bodyclose,exhaustive,durationcheck,gosec,misspell,nolintlint,rowserrcheck,sqlclosecheck,unused"
+    enabled="-E=asciicheck,bidichk,bodyclose,dupword,durationcheck,errchkjson,exhaustive,exportloopref,forcetypeassert,gosec,misspell,nolintlint,rowserrcheck,sqlclosecheck,thelper,unparam,unused,usestdlibvars,wastedassign"
     if [ -n "$GOLANGCI_LINTERS" ];
     then
         enabled="$enabled"",$GOLANGCI_LINTERS"


### PR DESCRIPTION
I was reviewing the [linters available in golangci-lint](https://golangci-lint.run/usage/linters/) and figured we could enable some more. 

- [dupword](https://github.com/Abirdcfly/dupword): A linter that checks for duplicate words in the source code
- [errchkjson](https://github.com/breml/errchkjson): Checks types passed to the json encoding functions.
- [exportloopref](https://github.com/kyoh86/exportloopref): An analyzer that finds exporting pointers for loop variables.
- [forcetypeassert](https://github.com/gostaticanalysis/forcetypeassert): Finds type assertions which did forcely such as below.
- [thelper](https://github.com/kulti/thelper): thelper detects golang test helpers without t.Helper()
- [unparam](https://github.com/mvdan/unparam): Reports unused function parameters and results in your code.
- [usestdlibvars](https://github.com/sashamelentyev/usestdlibvars): A linter that detect the possibility to use variables/constants from the Go standard library.
- [wastedassign](https://github.com/sanposhiho/wastedassign): finds wasted assignment statements