### PR TITLE
Update lint-project.sh

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -257,12 +257,17 @@ linters:
 linters-settings:
   forbidigo:
     forbid:
-      - '^panic$'
 EOF
         # Add some specific overrides
         if [[ "$GOLANGCI_ALLOW_PRINT" != "yes" ]];
         then
             echo "      - ^fmt\.Print.*$" >> "$configFilepath"
+        fi
+
+        # Add some specific overrides
+        if [[ "$GOLANGCI_ALLOW_PANIC" != "yes" ]];
+        then
+            echo "      - ^panic$" >> "$configFilepath"
         fi
 
         # Run golangci-lint over non-test code first with forbidigo


### PR DESCRIPTION
The `lint-project.sh` script currently runs `golangci-lint` in two separate instances. Initially, it's executed with all linters turned off except for **forbidigo** ([see reference](https://github.com/moov-io/infra/blob/master/go/lint-project.sh#L269)). Following this, it is run again, this time with all linters enabled except for **forbidigo** ([see reference](https://github.com/moov-io/infra/blob/master/go/lint-project.sh#L296)).

To bypass the **forbidigo** linter for specific files that utilize `panic`, the `//nolint` directive was used. This directive was effective only during the first instance of the linting process. However, during the second linting round, the `//nolint` directive becomes superfluous since **forbidigo** is not active. This redundancy leads to the detection of an unused `nolintlint` directive error, as illustrated in the [following output](https://github.com/moov-io/iso8583/actions/runs/6265347613/job/17014007319?pr=284#step:4:101):

```
Error: message.go:42:14: directive `//nolint // as specs moslty static, we panic on spec validation errors` is unused (nolintlint)
		panic(err) //nolint // as specs moslty static, we panic on spec validation errors
```

With this PR, we introduce the GOLANGCI_ALLOW_PANIC environment variable. When it's set to yes, no checks for panic are performed by **forbidigo**. It's done similarly to `GOLANGCI_ALLOW_PRINT`.

P.S. it's not a viable option to remove `panic` from https://github.com/moov-io/iso8583/ (see https://github.com/moov-io/iso8583/issues/269)