### PR TITLE
go/lint: ignore "pkg/*test" directories in coverage analysis

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -15,6 +15,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: stable
+        id: go
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -355,11 +355,12 @@ fi
 
 coveredStatements=0
 maximumCoverage=0
+coveragePath=$(mktemp -d)"/coverage.txt"
 
 # Run 'go test'
 if [[ "$OS_NAME" == "windows" ]]; then
     # Just run short tests on Windows as we don't have Docker support in tests worked out for the database tests
-    go test $GOTAGS "$gotest_packages" "$GORACE" -short -coverprofile=coverage.txt -covermode=atomic $GOTEST_FLAGS
+    go test $GOTAGS "$gotest_packages" "$GORACE" -short -coverprofile="$coveragePath" -covermode=atomic $GOTEST_FLAGS
 fi
 # Add some default flags to every 'go test' case
 if [[ "$GOTEST_FLAGS" == "" ]]; then
@@ -399,15 +400,17 @@ if [[ "$OS_NAME" != "windows" ]]; then
             done
         else
             # Otherwise just run Go tests without profiling
-            go test $GOTAGS "$gotest_packages" "$GORACE" -coverprofile=coverage.txt -covermode=atomic -count 1 $GOTEST_FLAGS
+            go test $GOTAGS "$gotest_packages" "$GORACE" -coverprofile="$coveragePath" -covermode=atomic -count 1 $GOTEST_FLAGS
         fi
     fi
 fi
 
 # Verify Code Coverage Threshold
 if [[ "$COVER_THRESHOLD" != "" ]]; then
-    if [[ -f coverage.txt && "$PROFILE_GOTEST" != "yes" ]];
+    if [[ -f "$coveragePath" && "$PROFILE_GOTEST" != "yes" ]];
     then
+        # Ignore test directories in coverage analysis
+        cat "$coveragePath" | grep -v -E "./pkg*/*test" > coverage.txt
         coveredStatements=$(go tool cover -func=coverage.txt | grep -E '^total:' | grep -Eo '[0-9]+\.[0-9]+')
         maximumCoverage=100
     fi


### PR DESCRIPTION
We use these as test helpers so they don't need tests themselves. 