### PR TITLE
go: exclude examples from test coverage

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -410,7 +410,7 @@ if [[ "$COVER_THRESHOLD" != "" ]]; then
     if [[ -f "$coveragePath" && "$PROFILE_GOTEST" != "yes" ]];
     then
         # Ignore test directories in coverage analysis
-        cat "$coveragePath" | grep -v -E "/pkg*/*test" | grep -v -E "/internal*/*test" > coverage.txt
+        cat "$coveragePath" | grep -v -E "/pkg*/*test" | grep -v -E "/internal*/*test" | grep -v -E "/examples*/*" > coverage.txt
         coveredStatements=$(go tool cover -func=coverage.txt | grep -E '^total:' | grep -Eo '[0-9]+\.[0-9]+')
         maximumCoverage=100
     fi


### PR DESCRIPTION
Exclude code examples [like these](https://github.com/moov-io/wire/tree/master/examples) from test coverage threshold in `lint-project.sh`.