### PR TITLE
Replace deprecated skip-dirs flag and update contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,4 +36,4 @@ A good quality PR will have the following characteristics:
 
 A good PR should be able to flow through a peer review system easily and quickly.
 
-Our Build pipeline utilizes [Travis-CI](https://travis-ci.org/moov-io/ach) to enforce many tools that you should add to your editor before issuing a pull request.
+Our Build pipeline utilizes [GitHub Actions](https://github.com/moov-io/infra/actions) to enforce many tools that you should add to your editor before issuing a pull request.

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -293,7 +293,8 @@ run:
   timeout: 5m
   tests: false
   go: "$GO_VERSION"
-  skip-dirs:
+issues:
+  exclude-dirs:
     - "cmd/*"
     - "admin"
     - "client"
@@ -349,7 +350,7 @@ EOF
             disabled="-D=$DISABLED_GOLANGCI_LINTERS"
         fi
 
-        ./bin/golangci-lint $GOLANGCI_FLAGS run "$enabled" "$disabled" --verbose --go="$GO_VERSION" --skip-dirs="(admin|client)" --timeout=5m $GOLANGCI_TAGS
+        ./bin/golangci-lint $GOLANGCI_FLAGS run "$enabled" "$disabled" --verbose --go="$GO_VERSION" --exclude-dirs="(admin|client)" --timeout=5m $GOLANGCI_TAGS
         echo "FINISHED golangci-lint checks"
 
         # Cleanup


### PR DESCRIPTION
For the contributing.md changes:

This one is pretty straightforward. It looks like this wasn't updated when we moved from TravisCI to GitHub Actions. I've updated the reference and its link to point to the Actions tab for this repository.

For the lint-project.sh changes:

While reviewing runs in the CI for some of our services, I noticed the messages shown in the screenshots below that indicate we need to update `skip-dirs` to `exclude-dirs`

<img width="1407" alt="Screenshot 2024-05-10 at 10 14 34 AM" src="https://github.com/moov-io/infra/assets/134305566/dd5b23aa-c59b-4a81-b1ea-8d305bad741a">
<img width="1103" alt="Screenshot 2024-05-10 at 10 16 02 AM" src="https://github.com/moov-io/infra/assets/134305566/1e66358a-acc6-4026-bd5c-aa37e671d7ce">


With the suggested changes, we no longer see these warning messages
<img width="1628" alt="Screenshot 2024-05-10 at 10 17 34 AM" src="https://github.com/moov-io/infra/assets/134305566/9128fd4b-a0e9-48b6-8798-c50d21e2c19c">


