### PR TITLE
go/lint: look for gotest instead of "go test"

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -399,10 +399,17 @@ coveredStatements=0
 maximumCoverage=0
 coveragePath=$(mktemp -d)"/coverage.txt"
 
+# Find "gotest" or "go test"
+GOTEST=$(which go)" test"
+if which -s gotest > /dev/null;
+then
+    GOTEST=$(which gotest 2>&1 | head -n1)
+fi
+
 # Run 'go test'
 if [[ "$OS_NAME" == "windows" ]]; then
     # Just run short tests on Windows as we don't have Docker support in tests worked out for the database tests
-    go test $GOTAGS "$gotest_packages" "$GORACE" -short -coverprofile="$coveragePath" -covermode=atomic $GOTEST_FLAGS
+    $GOTEST $GOTAGS "$gotest_packages" "$GORACE" -short -coverprofile="$coveragePath" -covermode=atomic $GOTEST_FLAGS
 fi
 # Add some default flags to every 'go test' case
 if [[ "$GOTEST_FLAGS" == "" ]]; then
@@ -413,7 +420,7 @@ if [[ "$GOTEST_FLAGS" == "" ]]; then
 fi
 if [[ "$OS_NAME" != "windows" ]]; then
     if [[ "$COVER_THRESHOLD" == "disabled" ]]; then
-        go test $GOTAGS "$gotest_packages" "$GORACE" -count 1 $GOTEST_FLAGS
+        $GOTEST $GOTAGS "$gotest_packages" "$GORACE" -count 1 $GOTEST_FLAGS
     else
         # Optionally profile each package
         if [[ "$PROFILE_GOTEST" == "yes" ]]; then
@@ -426,7 +433,7 @@ if [[ "$OS_NAME" != "windows" ]]; then
                     dir="."
                 fi
 
-                go test $GOTAGS "$pkg" "$GORACE" \
+                $GOTEST $GOTAGS "$pkg" "$GORACE" \
                    -covermode=atomic \
                    -coverprofile="$dir"/coverage.txt \
                    -test.cpuprofile="$dir"/cpu.out \
@@ -442,7 +449,7 @@ if [[ "$OS_NAME" != "windows" ]]; then
             done
         else
             # Otherwise just run Go tests without profiling
-            go test $GOTAGS "$gotest_packages" "$GORACE" -coverprofile="$coveragePath" -covermode=atomic -count 1 $GOTEST_FLAGS
+            $GOTEST $GOTAGS "$gotest_packages" "$GORACE" -coverprofile="$coveragePath" -covermode=atomic -count 1 $GOTEST_FLAGS
         fi
     fi
 fi


### PR DESCRIPTION
`gotest` is an [awesome CLI tool](https://github.com/rakyll/gotest) that wraps `go test` and highlights the results. @ahrtmn had the idea to use it if found during `make check`.

We could even start to install it on some runners. 