### PR TITLE
go/lint: auto format files with gofmt that need it

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -54,8 +54,14 @@ if [[ "$OS_NAME" != "windows" ]]; then
         test -z $(gofmt -s -l $file)
         if [[ $? != 0 ]];
         then
-            code=1
-            echo "$file is not formatted"
+            echo "DEBUG: formatting $file with gofmt"
+
+            test -z $(gofmt -s -w $file)
+            if [[ $? != 0 ]];
+            then
+                echo "ERROR: problem rewriting $file"
+                exit 1;
+            fi
         fi
     done
     set -e


### PR DESCRIPTION
`-s` often trips people up

Instead of getting an error like:
```
./tests/code/plugin.go is not formatted
```

The linter will now attempt to format files
```
DEBUG: formatting ./tests/code/plugin.go with gofmt
```