### PR TITLE
go/lint: move gofmt into golangci-lint and add ONLY_GOLANGCI flag

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -355,7 +355,7 @@ if [[ "$OS_NAME" != "windows" ]]; then
 
         # Build the linters list
         # TODO(adam): re-add unused when they fix some bugs
-        default_linters="asciicheck,bidichk,bodyclose,durationcheck,exhaustive,fatcontext,forcetypeassert,gofmt,gosec,misspell,nolintlint,protogetter,rowserrcheck,sqlclosecheck,testifylint,wastedassign"
+        default_linters="asciicheck,bidichk,bodyclose,durationcheck,exhaustive,fatcontext,forcetypeassert,gosec,misspell,nolintlint,protogetter,rowserrcheck,sqlclosecheck,testifylint,wastedassign"
         enabled="$default_linters"
 
         if [ -n "$GOLANGCI_LINTERS" ]; then
@@ -388,11 +388,15 @@ version: "2"
 run:
   tests: false
   go: "$GO_VERSION"
-linters:
-  default: none
+formatters:
+  enable:
+    - gofmt
   settings:
     gofmt:
       simplify: true
+linters:
+  default: none
+  settings:
     gosec:
       excludes:
         - G101 # Potential hardcoded credentials

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -47,53 +47,6 @@ if [[ "$ONLY_GOLANGCI" == "yes" ]]; then
     SKIP_TESTS=yes
 fi
 
-# Check gofmt
-run_gofmt=true
-if [[ "$SKIP_LINTERS" != "" ]]; then
-    run_gofmt=false
-fi
-if [[ "$ONLY_GOLANGCI" == "yes" ]]; then
-    run_gofmt=false
-fi
-if [[ "$OS_NAME" == "windows" ]]; then
-    run_gofmt=false
-fi
-if [[ "$run_gofmt" == "true" ]]; then
-    set +e
-    code=0
-    for file in "${GOFILES[@]}"
-    do
-        # Go 1.17 introduced a migration with build constraints
-        # and they offer a migration with gofmt
-        # See https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md#transition for more details
-        if [[ "$file" == "./pkged.go" ]];
-        then
-            gofmt -s -w pkged.go
-        fi
-
-        # Check the file's formatting
-        test -z $(gofmt -s -l $file)
-        if [[ $? != 0 ]];
-        then
-            echo "DEBUG: formatting $file with gofmt"
-
-            test -z $(gofmt -s -w $file)
-            if [[ $? != 0 ]];
-            then
-                echo "ERROR: problem rewriting $file"
-                exit 1;
-            fi
-        fi
-    done
-    set -e
-    if [[ $code != 0 ]];
-    then
-        exit $code
-    fi
-
-    echo "finished gofmt check"
-fi
-
 # Would be set to 'moov-io' or 'moovfinancial'
 org=$(go mod why | head -n1  | awk -F'/' '{print $2}')
 
@@ -402,7 +355,7 @@ if [[ "$OS_NAME" != "windows" ]]; then
 
         # Build the linters list
         # TODO(adam): re-add unused when they fix some bugs
-        default_linters="asciicheck,bidichk,bodyclose,durationcheck,exhaustive,fatcontext,forcetypeassert,gosec,misspell,nolintlint,protogetter,rowserrcheck,sqlclosecheck,testifylint,wastedassign"
+        default_linters="asciicheck,bidichk,bodyclose,durationcheck,exhaustive,fatcontext,forcetypeassert,gofmt,gosec,misspell,nolintlint,protogetter,rowserrcheck,sqlclosecheck,testifylint,wastedassign"
         enabled="$default_linters"
 
         if [ -n "$GOLANGCI_LINTERS" ]; then
@@ -438,6 +391,8 @@ run:
 linters:
   default: none
   settings:
+    gofmt:
+      simplify: true
     gosec:
       excludes:
         - G101 # Potential hardcoded credentials

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -44,6 +44,7 @@ fi
 if [[ "$ONLY_GOLANGCI" == "yes" ]]; then
     DISABLE_GITLEAKS=yes
     DISABLE_GOVULNCHECK=yes
+    EXPERIMENTAL=""
     SKIP_TESTS=yes
 fi
 

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -430,19 +430,14 @@ EOF
             echo "        - pattern: ^fmt\.Print.*$" >> "$configFilepath"
         fi
 
-        cat <<EOF >> "$configFilepath"
-  enable:
-    - $(echo $enabled | sed 's/,/\n    - /g')
-  disable:
-    - depguard
-    - errcheck
-EOF
-        if [[ "$DISABLED_GOLANGCI_LINTERS" != "" ]];
-        then
-            cat <<EOF >> "$configFilepath"
-    - $(echo "$DISABLED_GOLANGCI_LINTERS" | sed 's/,/\n    - /g')
-EOF
+        # Build --enable and --disable flags from env vars rather than config
+        GOLANGCI_ENABLE_FLAG="--enable=$enabled"
+
+        disabled="depguard,errcheck"
+        if [[ "$DISABLED_GOLANGCI_LINTERS" != "" ]]; then
+            disabled="$disabled,$DISABLED_GOLANGCI_LINTERS"
         fi
+        GOLANGCI_DISABLE_FLAG="--disable=$disabled"
 
         cat <<EOF >> "$configFilepath"
   exclusions:
@@ -478,7 +473,7 @@ EOF
         if [[ "$GOLANGCI_DO_FIX" == "true" ]]; then
             GOLANGCI_FIX_FLAG="--fix"
         fi
-        ./bin/golangci-lint $GOLANGCI_FLAGS run --config="$configFilepath" $GOLANGCI_FIX_FLAG --verbose --timeout=5m $GOLANGCI_TAGS
+        ./bin/golangci-lint $GOLANGCI_FLAGS run --config="$configFilepath" $GOLANGCI_FIX_FLAG $GOLANGCI_ENABLE_FLAG $GOLANGCI_DISABLE_FLAG --verbose --timeout=5m $GOLANGCI_TAGS
 
         echo "FINISHED golangci-lint checks"
 

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -40,9 +40,19 @@ else
     echo "running go linters for $OS_NAME"
 fi
 
+# ONLY_GOLANGCI=yes skips all checks except golangci-lint (and its --fix via GOLANGCI_DO_FIX=true)
+if [[ "$ONLY_GOLANGCI" == "yes" ]]; then
+    DISABLE_GITLEAKS=yes
+    DISABLE_GOVULNCHECK=yes
+    SKIP_TESTS=yes
+fi
+
 # Check gofmt
 run_gofmt=true
 if [[ "$SKIP_LINTERS" != "" ]]; then
+    run_gofmt=false
+fi
+if [[ "$ONLY_GOLANGCI" == "yes" ]]; then
     run_gofmt=false
 fi
 if [[ "$OS_NAME" == "windows" ]]; then
@@ -88,7 +98,7 @@ fi
 org=$(go mod why | head -n1  | awk -F'/' '{print $2}')
 
 # Reject moovfinancial dependencies in moov-io projects
-if [[ "$org" == "moov-io" ]];
+if [[ "$ONLY_GOLANGCI" != "yes" && "$org" == "moov-io" ]];
 then
     # Fail our build if we find moovfinancial dependencies
     if go list -m all | grep moovfinancial;
@@ -115,6 +125,9 @@ then
 fi
 
 # Verify no retracted module versions are in the build
+if [[ "$ONLY_GOLANGCI" == "yes" ]]; then
+    retracted_mods=()
+else
 retracted_mods=($(go list -m -u all | grep retracted | cut -f1 -d' '))
 skip_modules=(
     "github.com/moby/sys/user"
@@ -145,9 +158,10 @@ do
         fi
     fi
 done
+fi
 
 # Build the source code (to discover compile errors prior to linting)
-if [[ "$SKIP_LINTERS" == "" ]]; then
+if [[ "$SKIP_LINTERS" == "" && "$ONLY_GOLANGCI" != "yes" ]]; then
     echo "Building Go source code"
     go build $GORACE $GOTAGS $GOBUILD_FLAGS ./...
     echo "SUCCESS: Go code built without errors"


### PR DESCRIPTION
## Summary
- Removes the standalone `gofmt` check and adds `gofmt` (with `simplify: true`) as a linter within `golangci-lint`
- Adds `ONLY_GOLANGCI=yes` flag to skip all other checks (dependency validation, retracted modules, build, tests) and run only `golangci-lint`

## Test plan
- [ ] Run `ONLY_GOLANGCI=yes bash lint-project.sh` and verify only golangci-lint runs
- [ ] Run `bash lint-project.sh` normally and verify gofmt formatting is still checked via golangci-lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)