### PR TITLE
added the config for staticcheck, only turning on those that autofix right now

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -435,6 +435,16 @@ EOF
             echo "        - pattern: ^fmt\.Print.*$" >> "$configFilepath"
         fi
 
+        # Limit staticcheck to auto-fixable rules only (QF* and S1*).
+        # SA* and ST* rules are higher-signal but require manual fixes
+        # They should eventually be turned on as well
+        cat <<EOF >> "$configFilepath"
+    staticcheck:
+      checks:
+        - "-SA*"
+        - "-ST*"
+EOF
+
         # Build --enable and --disable flags from env vars rather than config
         GOLANGCI_ENABLE_FLAG="--enable=$enabled"
 

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -435,14 +435,20 @@ EOF
             echo "        - pattern: ^fmt\.Print.*$" >> "$configFilepath"
         fi
 
-        # Limit staticcheck to auto-fixable rules only (QF* and S1*).
-        # SA* and ST* rules are higher-signal but require manual fixes
-        # They should eventually be turned on as well
+        # Enable staticcheck with auto-fixable rules only: all S1* (simplifications)
+        # and a curated subset of QF* (quickfixes). SA* and ST* require manual fixes
+        # but should be considered to be turned on at some point...
         cat <<EOF >> "$configFilepath"
     staticcheck:
       checks:
-        - "-SA*"
-        - "-ST*"
+        - "none"
+        - "S1*"
+        - "QF1004"
+        - "QF1005"
+        - "QF1006"
+        - "QF1009"
+        - "QF1010"
+        - "QF1012"
 EOF
 
         # Build --enable and --disable flags from env vars rather than config


### PR DESCRIPTION

This added the config for the staticcheck linter.  It is only
turning on those rules in staticcheck that can be auto fixed.
This is only the config we will turn it on via a seperate PR
in templater.
