### PR TITLE
pin golangci version

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -2,7 +2,7 @@
 set -e
 
 gitleaks_version=8.17.0
-golangci_version="${GOLANGCI_LINT_VERSION:-latest}"
+golangci_version="${GOLANGCI_LINT_VERSION:-v2.11.4}"
 sqlvet_version=v1.1.5
 
 # Set these to any non-blank value to disable the linter


### PR DESCRIPTION
Seeing checksum failures from golangci.

The checksums file has hashes:
- 6b89d77b... → golangci-lint-2.12.0-linux-amd64.tar.gz (expected)
- 7976b120... → golangci-lint-2.12.0-linux-amd64.tar.gz.sbom.json

The CI error shows the downloaded .tar.gz hashes to 7976b120... — the SBOM checksum. It appears the .tar.gz release artifact was accidentally replaced with (or is serving) the SBOM file.