### PR TITLE
go/lint: skip govulncheck when dedicated workflow exists

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -169,6 +169,11 @@ fi
 if [[ "$SKIP_LINTERS" != "" ]]; then
     run_govulncheck=false
 fi
+if [[ -f ".github/workflows/govulncheck.yml" ]]; then
+    # Dedicated govulncheck workflow handles scanning (including weekly scheduled runs);
+    # skip here to avoid running twice on PRs.
+    run_govulncheck=false
+fi
 if [[ "$run_govulncheck" == "true" ]]; then
     echo "STARTING govulncheck check"
 


### PR DESCRIPTION
## Summary

- When a repo has `.github/workflows/govulncheck.yml`, skip the govulncheck run in `lint-project.sh` to avoid running it twice on every PR
- The check is a simple file existence test — no new env vars or config needed

## Context

moovfinancial/templater#564 adds a `govulncheck.yml` workflow template to the `go-github-actions-private` template category. That workflow:
- Runs govulncheck on PR and push (replacing this script's run)
- Adds a **weekly scheduled scan** to catch new CVEs between PRs (new capability)
- Uploads findings to the GitHub Security tab via SARIF for tracking and per-finding dismissal

Without this change, govulncheck would run twice on every PR in any repo that gets the new workflow template.

## Test plan

- [ ] Confirm `make check` skips govulncheck in a repo that has `.github/workflows/govulncheck.yml`
- [ ] Confirm `make check` still runs govulncheck in a repo without that file