### PR TITLE
go/lint: use committed .golangci.yml when present

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -359,13 +359,14 @@ if [[ "$OS_NAME" != "windows" ]]; then
 
         ./bin/golangci-lint version
 
+        GOLANGCI_FIX_FLAG=""
+        if [[ "$GOLANGCI_DO_FIX" == "true" ]]; then
+            GOLANGCI_FIX_FLAG="--fix"
+        fi
+
         # If the project has a committed .golangci.yml, use it directly and skip
         # dynamic config generation — the file controls all linter settings.
         if [[ -f ".golangci.yml" ]]; then
-            GOLANGCI_FIX_FLAG=""
-            if [[ "$GOLANGCI_DO_FIX" == "true" ]]; then
-                GOLANGCI_FIX_FLAG="--fix"
-            fi
             ./bin/golangci-lint $GOLANGCI_FLAGS run $GOLANGCI_FIX_FLAG --verbose --timeout=5m $GOLANGCI_TAGS
         else
         # Build the linters list
@@ -504,17 +505,13 @@ EOF
         path: '^(main\.go|cmd/|docs/|examples/|scripts/)'
 EOF
 
-        GOLANGCI_FIX_FLAG=""
-        if [[ "$GOLANGCI_DO_FIX" == "true" ]]; then
-            GOLANGCI_FIX_FLAG="--fix"
-        fi
         ./bin/golangci-lint $GOLANGCI_FLAGS run --config="$configFilepath" $GOLANGCI_FIX_FLAG $GOLANGCI_ENABLE_FLAG $GOLANGCI_DISABLE_FLAG --verbose --timeout=5m $GOLANGCI_TAGS
+
+        # Cleanup generated config
+        rm -f "$configFilepath"
         fi
 
         echo "FINISHED golangci-lint checks"
-
-        # Cleanup
-        rm -f ".golangci-lint-generated.yml"
     fi
 fi
 

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -359,6 +359,15 @@ if [[ "$OS_NAME" != "windows" ]]; then
 
         ./bin/golangci-lint version
 
+        # If the project has a committed .golangci.yml, use it directly and skip
+        # dynamic config generation — the file controls all linter settings.
+        if [[ -f ".golangci.yml" ]]; then
+            GOLANGCI_FIX_FLAG=""
+            if [[ "$GOLANGCI_DO_FIX" == "true" ]]; then
+                GOLANGCI_FIX_FLAG="--fix"
+            fi
+            ./bin/golangci-lint $GOLANGCI_FLAGS run $GOLANGCI_FIX_FLAG --verbose --timeout=5m $GOLANGCI_TAGS
+        else
         # Build the linters list
         # TODO(adam): re-add unused when they fix some bugs
         default_linters="asciicheck,bidichk,bodyclose,durationcheck,exhaustive,fatcontext,forcetypeassert,gosec,misspell,nolintlint,protogetter,rowserrcheck,sqlclosecheck,testifylint,wastedassign"
@@ -500,11 +509,12 @@ EOF
             GOLANGCI_FIX_FLAG="--fix"
         fi
         ./bin/golangci-lint $GOLANGCI_FLAGS run --config="$configFilepath" $GOLANGCI_FIX_FLAG $GOLANGCI_ENABLE_FLAG $GOLANGCI_DISABLE_FLAG --verbose --timeout=5m $GOLANGCI_TAGS
+        fi
 
         echo "FINISHED golangci-lint checks"
 
         # Cleanup
-        rm -f "$configFilepath"
+        rm -f ".golangci-lint-generated.yml"
     fi
 fi
 


### PR DESCRIPTION
## Summary

If a repo has a committed `.golangci.yml`, use it directly instead of generating
a temporary config at runtime. Repos without the file are unaffected.

This makes it easier for the moovfinancial templating system to roll out changes
to the linting process on a per-repo basis.