### PR TITLE
go/lint: download golangci-lint release tarball directly with anchored checksum verify

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -354,8 +354,31 @@ if [[ "$OS_NAME" != "windows" ]]; then
     else
         echo "STARTING golangci-lint checks"
 
-        # Download golangci-lint
-        wget -qO- https://golangci-lint.run/install.sh | sh -s -- -b ./bin "$golangci_version"
+        # Download golangci-lint. The release tarball is fetched and verified
+        # directly instead of via the upstream install.sh: that script's
+        # checksum verification uses an unanchored grep that breaks on
+        # releases shipping .sbom.json assets (the sbom line also matches the
+        # tarball filename, so its want-hash becomes a two-line string).
+        gl_version="$golangci_version"
+        if [[ "$gl_version" == "latest" ]]; then
+            gl_version=$(curl -sSfL -o /dev/null -w '%{url_effective}' https://github.com/golangci/golangci-lint/releases/latest | grep -Eo 'v[0-9][0-9.]*$')
+        fi
+        gl_arch=$(uname -m)
+        case "$gl_arch" in
+            x86_64) gl_arch=amd64 ;;
+            aarch64) gl_arch=arm64 ;;
+        esac
+        gl_name="golangci-lint-${gl_version#v}-${UNAME}-${gl_arch}"
+        gl_base="https://github.com/golangci/golangci-lint/releases/download/${gl_version}"
+        wget -q -O "./bin/${gl_name}.tar.gz" "${gl_base}/${gl_name}.tar.gz"
+        wget -q -O ./bin/golangci-lint-checksums.txt "${gl_base}/golangci-lint-${gl_version#v}-checksums.txt"
+        gl_sha_cmd="sha256sum"
+        if ! command -v sha256sum >/dev/null 2>&1; then
+            gl_sha_cmd="shasum -a 256"
+        fi
+        (cd ./bin && grep " ${gl_name}.tar.gz\$" golangci-lint-checksums.txt | $gl_sha_cmd -c -)
+        tar -xzf "./bin/${gl_name}.tar.gz" -C ./bin --strip-components=1 "${gl_name}/golangci-lint"
+        rm -f "./bin/${gl_name}.tar.gz" ./bin/golangci-lint-checksums.txt
 
         ./bin/golangci-lint version
 

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -340,24 +340,18 @@ then
 fi
 
 # Download a golangci-lint release binary into ./bin/golangci-lint.
-#
-# We intentionally do NOT use the upstream install.sh: golangci-lint
-# releases ship ".sbom.json" assets whose names contain the tarball name,
-# and the installer verifies checksums with an unanchored grep that
-# matches both lines — so its verification always fails.
+# Fetched directly from GitHub releases instead of the upstream install.sh,
+# whose checksum verification breaks on releases that include sbom assets.
 install_golangci_lint() {
     version="$1"
 
-    # "latest" is not a real tag. Resolve it by following the GitHub
-    # releases redirect (/releases/latest -> /releases/tag/vX.Y.Z).
+    # Resolve "latest" to a tag via the GitHub releases redirect.
     if [[ "$version" == "latest" ]]; then
         version=$(curl -sSfL -o /dev/null -w '%{url_effective}' \
             https://github.com/golangci/golangci-lint/releases/latest \
             | grep -Eo 'v[0-9][0-9.]*$')
     fi
 
-    # Release assets are named like golangci-lint-2.12.2-linux-amd64.tar.gz;
-    # map uname arch names onto the Go arch names used in the asset name.
     arch=$(uname -m)
     case "$arch" in
         x86_64)  arch=amd64 ;;
@@ -366,18 +360,14 @@ install_golangci_lint() {
     name="golangci-lint-${version#v}-${UNAME}-${arch}"
     release_url="https://github.com/golangci/golangci-lint/releases/download/${version}"
 
-    # Fetch the tarball and the release checksums file.
     wget -q -O "./bin/${name}.tar.gz" "${release_url}/${name}.tar.gz"
     wget -q -O ./bin/golangci-lint-checksums.txt "${release_url}/golangci-lint-${version#v}-checksums.txt"
 
-    # Verify the tarball. The trailing "$" anchors the filename so the
-    # .sbom.json checksum line cannot match. macOS ships shasum, not
-    # sha256sum.
+    # The anchored grep keeps the sbom checksum line from matching.
     sha_cmd="sha256sum"
     command -v sha256sum >/dev/null 2>&1 || sha_cmd="shasum -a 256"
     (cd ./bin && grep " ${name}.tar.gz\$" golangci-lint-checksums.txt | $sha_cmd -c -)
 
-    # Extract just the binary and clean up the download artifacts.
     tar -xzf "./bin/${name}.tar.gz" -C ./bin --strip-components=1 "${name}/golangci-lint"
     rm -f "./bin/${name}.tar.gz" ./bin/golangci-lint-checksums.txt
 }

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -339,6 +339,49 @@ then
     fi
 fi
 
+# Download a golangci-lint release binary into ./bin/golangci-lint.
+#
+# We intentionally do NOT use the upstream install.sh: golangci-lint
+# releases ship ".sbom.json" assets whose names contain the tarball name,
+# and the installer verifies checksums with an unanchored grep that
+# matches both lines — so its verification always fails.
+install_golangci_lint() {
+    version="$1"
+
+    # "latest" is not a real tag. Resolve it by following the GitHub
+    # releases redirect (/releases/latest -> /releases/tag/vX.Y.Z).
+    if [[ "$version" == "latest" ]]; then
+        version=$(curl -sSfL -o /dev/null -w '%{url_effective}' \
+            https://github.com/golangci/golangci-lint/releases/latest \
+            | grep -Eo 'v[0-9][0-9.]*$')
+    fi
+
+    # Release assets are named like golangci-lint-2.12.2-linux-amd64.tar.gz;
+    # map uname arch names onto the Go arch names used in the asset name.
+    arch=$(uname -m)
+    case "$arch" in
+        x86_64)  arch=amd64 ;;
+        aarch64) arch=arm64 ;;
+    esac
+    name="golangci-lint-${version#v}-${UNAME}-${arch}"
+    release_url="https://github.com/golangci/golangci-lint/releases/download/${version}"
+
+    # Fetch the tarball and the release checksums file.
+    wget -q -O "./bin/${name}.tar.gz" "${release_url}/${name}.tar.gz"
+    wget -q -O ./bin/golangci-lint-checksums.txt "${release_url}/golangci-lint-${version#v}-checksums.txt"
+
+    # Verify the tarball. The trailing "$" anchors the filename so the
+    # .sbom.json checksum line cannot match. macOS ships shasum, not
+    # sha256sum.
+    sha_cmd="sha256sum"
+    command -v sha256sum >/dev/null 2>&1 || sha_cmd="shasum -a 256"
+    (cd ./bin && grep " ${name}.tar.gz\$" golangci-lint-checksums.txt | $sha_cmd -c -)
+
+    # Extract just the binary and clean up the download artifacts.
+    tar -xzf "./bin/${name}.tar.gz" -C ./bin --strip-components=1 "${name}/golangci-lint"
+    rm -f "./bin/${name}.tar.gz" ./bin/golangci-lint-checksums.txt
+}
+
 # golangci-lint
 if [[ "$org" == "moov-io" ]];
 then
@@ -354,31 +397,7 @@ if [[ "$OS_NAME" != "windows" ]]; then
     else
         echo "STARTING golangci-lint checks"
 
-        # Download golangci-lint. The release tarball is fetched and verified
-        # directly instead of via the upstream install.sh: that script's
-        # checksum verification uses an unanchored grep that breaks on
-        # releases shipping .sbom.json assets (the sbom line also matches the
-        # tarball filename, so its want-hash becomes a two-line string).
-        gl_version="$golangci_version"
-        if [[ "$gl_version" == "latest" ]]; then
-            gl_version=$(curl -sSfL -o /dev/null -w '%{url_effective}' https://github.com/golangci/golangci-lint/releases/latest | grep -Eo 'v[0-9][0-9.]*$')
-        fi
-        gl_arch=$(uname -m)
-        case "$gl_arch" in
-            x86_64) gl_arch=amd64 ;;
-            aarch64) gl_arch=arm64 ;;
-        esac
-        gl_name="golangci-lint-${gl_version#v}-${UNAME}-${gl_arch}"
-        gl_base="https://github.com/golangci/golangci-lint/releases/download/${gl_version}"
-        wget -q -O "./bin/${gl_name}.tar.gz" "${gl_base}/${gl_name}.tar.gz"
-        wget -q -O ./bin/golangci-lint-checksums.txt "${gl_base}/golangci-lint-${gl_version#v}-checksums.txt"
-        gl_sha_cmd="sha256sum"
-        if ! command -v sha256sum >/dev/null 2>&1; then
-            gl_sha_cmd="shasum -a 256"
-        fi
-        (cd ./bin && grep " ${gl_name}.tar.gz\$" golangci-lint-checksums.txt | $gl_sha_cmd -c -)
-        tar -xzf "./bin/${gl_name}.tar.gz" -C ./bin --strip-components=1 "${gl_name}/golangci-lint"
-        rm -f "./bin/${gl_name}.tar.gz" ./bin/golangci-lint-checksums.txt
+        install_golangci_lint "$golangci_version"
 
         ./bin/golangci-lint version
 


### PR DESCRIPTION
## What

Replaces the `wget -qO- https://golangci-lint.run/install.sh | sh` invocation in `go/lint-project.sh` with a direct release-tarball download and an anchored checksum verification.

## Why

golangci-lint releases now ship `.sbom.json` assets alongside each tarball. The upstream install.sh verifies checksums with an unanchored `grep "${BASENAME}"`, which matches **two** lines in the checksums file (the tarball and `<tarball>.sbom.json`), making the expected hash a two-line string that can never match:

```
golangci/golangci-lint err hash_sha256_verify checksum for '…linux-arm64.tar.gz' did not verify
```

Every consumer of this script fails at the golangci-lint step regardless of OS/arch. The downloaded tarball itself is fine — only the installer's verify logic is broken.

## How

- Fetch `golangci-lint-<ver>-<os>-<arch>.tar.gz` and the release checksums file directly from GitHub releases
- Verify with `grep " <name>.tar.gz$"` (anchored) piped to `sha256sum -c` (falls back to `shasum -a 256` on macOS)
- `latest` resolves via the GitHub releases redirect URL
- Extract only the binary into `./bin/`, same location as before

## Testing

Verified on darwin-arm64 for both a pinned version (`v2.12.2`) and `latest`: checksum reports OK, binary runs. `bash -n` passes.