### PR TITLE
fix(ci): skip CodeQL on fork/private-fork PRs

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -6,8 +6,19 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   CodeQL-Build:
+    # Skip PRs from forks (including private forks of public repos). CodeQL needs
+    # security-events: write to upload results, which the default GITHUB_TOKEN does
+    # not grant on fork PRs, and private-module / secret access is usually missing.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Skip CodeQL when the PR head repo differs from the base (forks, including private forks).
- Avoids configuration failures from missing `security-events: write` / secrets on fork PRs.

## Test plan
- [ ] CodeQL still runs on push and same-repo PRs
- [ ] Fork PRs skip the job cleanly