### PR TITLE
ci: skip CodeQL when GitHub cannot accept SARIF

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -16,7 +16,7 @@ jobs:
     # Skip PRs from forks (including private forks of public repos). CodeQL needs
     # security-events: write to upload results, which the default GITHUB_TOKEN does
     # not grant on fork PRs, and private-module / secret access is usually missing.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ !github.event.repository.private && !github.event.repository.archived && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
GitHub only accepts CodeQL SARIF uploads on public (non-archived) repositories, or private repositories with GitHub Advanced Security.

This skips the CodeQL job when `repository.private` or `repository.archived` is set, so CI does not fail on upload with "Advanced Security must be enabled" / "Code scanning is not enabled".