### PR TITLE
feat: let lint-project.sh reuse a prebuilt golangci-lint and pass extra run flags

### DIFF
--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -5,6 +5,9 @@ gitleaks_version=8.17.0
 golangci_version="${GOLANGCI_LINT_VERSION:-latest}"
 sqlvet_version=v1.1.5
 
+# Additional flags for the golangci-lint run command (set by callers)
+GOLANGCI_FLAGS="${GOLANGCI_FLAGS:-}"
+
 # Set these to any non-blank value to disable the linter
 disable_golangci=""
 if [[ "$SKIP_GOLANGCI" != "" ]];
@@ -342,6 +345,9 @@ fi
 # Download a golangci-lint release binary into ./bin/golangci-lint.
 # Fetched directly from GitHub releases instead of the upstream install.sh,
 # whose checksum verification breaks on releases that include sbom assets.
+# If ./bin/golangci-lint already exists and matches the requested version it is
+# reused, so callers can pre-place their own build (for example one made with
+# 'golangci-lint custom' to link in module plugins).
 install_golangci_lint() {
     version="$1"
 
@@ -350,6 +356,15 @@ install_golangci_lint() {
         version=$(curl -sSfL -o /dev/null -w '%{url_effective}' \
             https://github.com/golangci/golangci-lint/releases/latest \
             | grep -Eo 'v[0-9][0-9.]*$')
+    fi
+
+    # Reuse a pre-existing binary of the requested version instead of
+    # downloading the release build. The trailing character guard keeps
+    # v2.13.1 from matching a v2.13.10 binary.
+    if [[ -x "./bin/golangci-lint" ]] &&
+        ./bin/golangci-lint version 2>/dev/null | grep -qE "version ${version#v}($|[^0-9.])"; then
+        echo "Reusing existing ./bin/golangci-lint for ${version}"
+        return
     fi
 
     arch=$(uname -m)

--- a/go/lint-project.sh
+++ b/go/lint-project.sh
@@ -359,10 +359,12 @@ install_golangci_lint() {
     fi
 
     # Reuse a pre-existing binary of the requested version instead of
-    # downloading the release build. The trailing character guard keeps
-    # v2.13.1 from matching a v2.13.10 binary.
+    # downloading the release build. A custom build reports its version with
+    # a leading 'v' and a build suffix (e.g. v2.13.1-custom-gcl-<hash>), so
+    # the match allows both forms. The trailing character guard keeps v2.13.1
+    # from matching a v2.13.10 binary.
     if [[ -x "./bin/golangci-lint" ]] &&
-        ./bin/golangci-lint version 2>/dev/null | grep -qE "version ${version#v}($|[^0-9.])"; then
+        ./bin/golangci-lint version 2>/dev/null | grep -qE "version v?${version#v}($|[^0-9.])"; then
         echo "Reusing existing ./bin/golangci-lint for ${version}"
         return
     fi


### PR DESCRIPTION
## What

Two small, generic extensions to `go/lint-project.sh`:

1. **Reuse a prebuilt golangci-lint.** `install_golangci_lint` now skips the release download when `./bin/golangci-lint` already exists and its `version` output matches the requested version. This lets a caller pre-place its own golangci-lint build before invoking the script — for example a binary produced by `golangci-lint custom` with module plugins linked in (https://golangci-lint.run/docs/plugins/module-plugins/). Projects that never pre-place a binary see no behavior change: the release binary is downloaded exactly as before. A trailing-character guard keeps `v2.13.1` from accidentally matching a `v2.13.10` binary, and a version mismatch falls through to a fresh download.

2. **`GOLANGCI_FLAGS` from the environment.** The variable was already interpolated into both `golangci-lint run` invocations but could not be set by callers. It now defaults to empty and can be exported by wrapper scripts/makefiles that need extra run flags (e.g. `--new-from-rev`).

## Why

golangci-lint's module-plugin mechanism is the documented way to add custom analyzers, but the script's unconditional download made plugin builds unusable here: any project that linked plugins in had to re-implement the surrounding checks (build, govulncheck, nilaway, coverage) in its own wrapper. With binary reuse, the script stays the single source of those checks and the caller only decides which golangci-lint binary runs them.

## Testing

- `bash -n` clean
- Version-match regex verified against a real v2.13.1 binary: exact version matches, `2.13.10` and `2.13` do not
- Unchanged path (no prebuilt binary) verified by inspection: guard short-circuits on `-x ./bin/golangci-lint` and the original download logic runs unchanged